### PR TITLE
Update Github workflows to run unit tests

### DIFF
--- a/.github/install-etcd.sh
+++ b/.github/install-etcd.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Fail on any error
+set -e
+
+ETCD_VERSION=v3.5.0
+INSTALL_DIR="/usr/local/bin"
+
+wget -q https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz
+mkdir -p ${INSTALL_DIR}
+tar xzf etcd-*-linux-amd64.tar.gz -C ${INSTALL_DIR} --strip-components=1
+rm -rf etcd*.gz

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,37 +1,44 @@
 name: Build and Push
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
-    types: [closed]
 
 jobs:
-  build:
-    if: github.event.pull_request.merged == true
+  test:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-    - name: Build runtime image 
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Install etcd
+      run: sudo ./.github/install-etcd.sh
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: kserve/modelmesh
+      IMAGE_TAG: latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build runtime image
       run: |
         GIT_COMMIT=$(git rev-parse HEAD)
         BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
-        IMAGE_TAG=main_${BUILD_ID}
-        BASE_IMAGE_TAG=$(cat BASE_IMAGE_TAG | awk -F= '{print $2}')
 
-        docker build -t modelmesh:${IMAGE_TAG} \
+        docker build -t ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
           --build-arg imageVersion=${IMAGE_TAG} \
           --build-arg buildId=${BUILD_ID} \
-          --build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} \
           --build-arg commitSha=${GIT_COMMIT} .
 
-    - name: Log in to docker hub
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+    - name: Log in to Docker Hub
+      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-    - name: Push to docker hub
+    - name: Push to Docker Hub
       run: |
-        IMAGE_NAME=modelmesh
-        IMAGE_ID=kserve/$IMAGE_NAME
-        IMAGE_VERSION=latest
-
-        docker push $IMAGE_ID:$IMAGE_VERSION
+        docker push ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,27 +1,20 @@
 name: Unit Test
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]        
+    branches: [ main ]
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-    - name: Build and test 
-      run: |
-        GIT_COMMIT=$(git rev-parse HEAD)
-        BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
-        IMAGE_TAG=main_${BUILD_ID}
-        BASE_IMAGE_TAG=$(cat BASE_IMAGE_TAG | awk -F= '{print $2}')
-
-        docker build -t modelmesh:${IMAGE_TAG} \
-          --build-arg imageVersion=${IMAGE_TAG} \
-          --build-arg buildId=${BUILD_ID} \
-          --build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} \
-          --build-arg commitSha=${GIT_COMMIT} .
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Install etcd
+      run: sudo ./.github/install-etcd.sh
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ LABEL image="build"
 
 COPY / /build
 
-RUN mvn -Dmaven.repo.local=repo -DskipTests=true -B clean install
+RUN mvn -B package -DskipTests=true --file pom.xml
 
 ###############################################################################
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshTearDownTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshTearDownTest.java
@@ -319,6 +319,6 @@ public class ModelMeshTearDownTest {
 
     public static int killProcess(Process process) throws Exception {
         int pid = getPID(process);
-        return Runtime.getRuntime().exec("command kill -9 " + pid).waitFor();
+        return Runtime.getRuntime().exec("kill -9 " + pid).waitFor();
     }
 }


### PR DESCRIPTION
- There is a unit test workflow for gating pull requests.
- Then there is also a workflow that, on each push, runs tests then builds/pushes to docker hub if the tests pass.
- The `command` was removed from the ModelMeshTearDown test because the test would fail with `no such file or directory` for `command`.

Note, tests are not run from the `docker build` command because of the `-DskipTests=true` in the `mvn` command in the Dockerfile. Removing the `skipTests` flag and running the tests during the image build always fails in the GitHub Actions environment after the tests complete due to connection time outs. 

Ex:
```
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 49, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- maven-jar-plugin:3.1.2:jar (default-jar) @ model-mesh ---
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.4.0/maven-archiver-3.4.0.pom
[INFO] I/O exception (java.net.SocketException) caught when processing request to {s}->https://repo.maven.apache.org:443: Connection timed out (Read failed)
[INFO] Retrying request to {s}->https://repo.maven.apache.org:443
[INFO] I/O exception (java.net.SocketException) caught when processing request to {s}->https://repo.maven.apache.org:443: Connection timed out (Read failed)
[INFO] Retrying request to {s}->https://repo.maven.apache.org:443
```
I have been unable to figure out why exactly this happens, but it might possibly be due to the amount of time the tests take or some other side effect? Skipping the tests doesn't see this timeout issue.