### PR TITLE
chore: Add release tag workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -3,6 +3,8 @@ name: Build and Push
 on:
   push:
     branches: [ main ]
+    tags:
+      - v*
 
 jobs:
   test:
@@ -23,22 +25,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: kserve/modelmesh
-      IMAGE_TAG: latest
     steps:
     - uses: actions/checkout@v2
-    - name: Build runtime image
+    - name: Build and push runtime image
       run: |
         GIT_COMMIT=$(git rev-parse HEAD)
         BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
 
-        docker build -t ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
-          --build-arg imageVersion=${IMAGE_TAG} \
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+        # Use Docker `latest` tag convention
+        [ "$VERSION" == "main" ] && VERSION=latest
+        echo $VERSION
+
+        docker build -t ${{ env.IMAGE_NAME }}:$VERSION \
+          --build-arg imageVersion=$VERSION \
           --build-arg buildId=${BUILD_ID} \
           --build-arg commitSha=${GIT_COMMIT} .
 
-    - name: Log in to Docker Hub
-      run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_ACCESS_TOKEN }}
-
-    - name: Push to Docker Hub
-      run: |
-        docker push ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+        docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_ACCESS_TOKEN }}
+        docker push ${{ env.IMAGE_NAME }}:$VERSION


### PR DESCRIPTION
#### Motivation

We want version tagged docker images to be pushed to DockerHub when a new release is tagged in GitHub.

#### Modifications

Adjusted the workflow file to also test, build, and push the image on tags.

#### Result

Tagged image versions on DockerHub.