### PR TITLE
chore: remove distribution management from maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,14 +273,6 @@
     </pluginManagement>
   </build>
 
-  <distributionManagement>
-    <snapshotRepository>
-        <id>ossrh</id>
-        <name>Central Repository OSSRH</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
#### Motivation

Using model-mesh as a maven artifact is a legacy “library integration” case which we should consider deprecated. Currently we are not deploying the maven artifact even so we do not need this.
