### PR TITLE
fix: Avoid possibility of distributed deadlock

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/StaticModelRegistration.java
+++ b/src/main/java/com/ibm/watson/modelmesh/StaticModelRegistration.java
@@ -150,10 +150,8 @@ public final class StaticModelRegistration {
             logger.info("Waiting for " + waitFor.size() + " models to be loaded before proceeding: " + waitFor);
             long oneYearAgo = System.currentTimeMillis() - TimeUnit.MILLISECONDS.convert(365L, TimeUnit.DAYS);
             for (String modelId : waitFor) {
-                ThreadContext.removeCurrentContext();
-                ThreadContext.addContextEntry(ModelMesh.UNBALANCED_KEY, "true");
                 // Use very old timestamp which will effectively leave the existing one unchanged
-                StatusInfo si = modelMesh.ensureLoaded(modelId, oneYearAgo, null, true, true);
+                StatusInfo si = modelMesh.ensureLoadedInternal(modelId, oneYearAgo, 0, null, 0, true);
                 if (si.getStatus() == Status.LOADING_FAILED) {
                     logger.error("Model " + modelId + " has status " + Status.LOADING_FAILED + ": "
                                  + si.getErrorMessages() + ", aborting");

--- a/src/main/java/com/ibm/watson/modelmesh/VModelManager.java
+++ b/src/main/java/com/ibm/watson/modelmesh/VModelManager.java
@@ -708,11 +708,8 @@ public final class VModelManager implements AutoCloseable {
                         lastUsed = currentTimeMillis() - ModelMesh.LASTUSED_AGE_ON_ADD_MS;
                     }
 
-                    ThreadContext.removeCurrentContext(); // ensure context is clear
-                    // add flag to ensure we aren't specially favoured
-                    ThreadContext.addContextEntry(ModelMesh.UNBALANCED_KEY, "true");
                     // this will block until loaded
-                    StatusInfo si = modelMesh.ensureLoaded(toId, lastUsed, null, true, true);
+                    StatusInfo si = modelMesh.ensureLoadedInternal(toId, lastUsed, 0, null, 0, true);
                     if (si == null) {
                         return; // shouldn't happen
                     }


### PR DESCRIPTION
#### Motivation

A deadlock-type state was observed where all of the model loading threads were stuck waiting for space to be freed by unloads, and all of the 10 "task" threads that are used for scheduling unloads were stuck waiting for internal `ensureLoaded` calls to complete.

It's not clear (yet) why the remote internal `ensureLoaded` calls were stuck because they do not block wait for the loading to complete. But this was in a test cluster under heavy inferencing and model registration load.

#### Modifications

- Add 3 second timeout for the internal `ensureLoaded` calls and ensure that `ensureLoadedInternal()` is used consistently for these
- Add a separate threadpool for async internal requests to limit how many run in parallel and to "protect" the main `taskPool` in case they get stuck (even though the timeout is now in place)
- Improve exception/logging messages related to timeouts (in particular avoid misleading "Unexpected internalOperation" messages)
- Add a new "in-" thread name prefix to distinguish from "ex-" where the request originates internally

#### Result

Avoid possible deadlock situation under heavy load

Signed-off-by: Nick Hill <nickhill@us.ibm.com>