### PR TITLE
fix: Fix for eviction deadlock

### DIFF
--- a/src/test/java/com/ibm/watson/modelmesh/SidecarModelMeshTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/SidecarModelMeshTest.java
@@ -158,7 +158,7 @@ public class SidecarModelMeshTest extends SingleInstanceModelMeshTest {
         assertEquals(ModelStatus.LOADING_FAILED, statusInfo.getModelCopyInfos(0).getCopyStatus());
         assertFalse(Strings.isNullOrEmpty(statusInfo.getModelCopyInfos(0).getLocation()));
         long age = System.currentTimeMillis() - statusInfo.getModelCopyInfos(0).getTime();
-        assertTrue(age > 0L && age < 15000L, "time " + statusInfo.getModelCopyInfos(0).getTime()
+        assertTrue(age >= 0L && age < 15000L, "time " + statusInfo.getModelCopyInfos(0).getTime()
                                              + " age " + age + "ms");
     }
 


### PR DESCRIPTION
#### Motivation

A recent fix for a cascading eviction race condition introduced the possibility of a deadlock between the model cache lock and per-cache entry locks due to eviction callback logic now performed in-line under the cache lock.

#### Modifications

Rework cache accounting logic to make an eviction/unload related adjustment unconditionally up-front within the cache lock so that it can be released before the entry removal/unload processing is performed along with state-dependent readjustment if necessary.

Also:
- Ensure all entry weight updates are guarded by the cache lock
- Change the cache's `oldestTime()` method to not take the cache lock since it's used on the inference request path

#### Result

Hopefully no more deadlocks

Signed-off-by: Nick Hill <nickhill@us.ibm.com>