### PR TITLE
fix: Longer timeout for blocking internal requests

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
@@ -6790,14 +6790,12 @@ public abstract class ModelMesh extends ThriftService
             ThreadContext.addContextEntry(UNBALANCED_KEY, "true");
         }
         ThreadContext.addContextEntry(TAS_INTERNAL_CXT_KEY, INTERNAL_REQ);
-        Context deadlineContext = Context.current().withDeadlineAfter(3L + chainedLoadCount, SECONDS, taskPool);
-        Context prevContext = deadlineContext.attach();
-        try (GrpcSupport.InterruptingListener cancelListener = newInterruptingListener()) {
+        // Set 3 second timeout or 10 minute "safeguard" if blocking
+        ThreadContext.setDeadlineAfter(sync ? 600L : 3L + chainedLoadCount, SECONDS);
+        try {
             return ensureLoaded(modelId, lastUsedTime, toExclude, sync, true);
         } catch (ModelNotFoundException mnfe) {
             return SI_NOT_FOUND;
-        } finally {
-            deadlineContext.detach(prevContext);
         }
     }
 


### PR DESCRIPTION
#### Motivation

Prior PR https://github.com/kserve/modelmesh/pull/26 added safeguard timeouts to internal `ensureLoaded` requests, but these were set to 3 seconds and did not take the blocking (sync=true) case into account where times are expected to sometimes be longer.

This could have the effect of causing small delays in VModel transitions and possibly cause pod shutdown to happen too quickly.

#### Modification

- Use a longer "safeguard" timeout of 10 minutes for blocking internal `ensureLoaded` requests
- Set only the litelinks timeout rather than gRPC context deadline (less overhead), since gRPC isn't used for intra-cluster requests

#### Result

Avoid potential disruption to VModel transition and model propagation during shutdown.

Signed-off-by: Nick Hill <nickhill@us.ibm.com>