### PR TITLE
fix: Always block internal management RPCs when on inference path

### DIFF
--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshRefreshMissingModelTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshRefreshMissingModelTest.java
@@ -19,6 +19,7 @@ package com.ibm.watson.modelmesh;
 import com.ibm.watson.modelmesh.api.ModelInfo;
 import com.ibm.watson.modelmesh.api.ModelMeshGrpc;
 import com.ibm.watson.modelmesh.api.ModelMeshGrpc.ModelMeshBlockingStub;
+import com.ibm.watson.modelmesh.api.ModelRuntimeGrpc;
 import com.ibm.watson.modelmesh.api.ModelStatusInfo.ModelStatus;
 import com.ibm.watson.modelmesh.api.RegisterModelRequest;
 import com.ibm.watson.modelmesh.api.UnloadModelRequest;
@@ -27,8 +28,6 @@ import com.ibm.watson.modelmesh.example.api.ExamplePredictorGrpc;
 import com.ibm.watson.modelmesh.example.api.ExamplePredictorGrpc.ExamplePredictorBlockingStub;
 import com.ibm.watson.modelmesh.example.api.Predictor.PredictRequest;
 import com.ibm.watson.modelmesh.example.api.Predictor.PredictResponse;
-import com.ibm.watson.tas.internal.proto.ModelServerGrpc;
-import com.ibm.watson.tas.internal.proto.ModelServerGrpc.ModelServerBlockingStub;
 import io.grpc.ManagedChannel;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
@@ -81,8 +80,7 @@ public class ModelMeshRefreshMissingModelTest extends AbstractModelMeshClusterTe
                 // Perform a sneaky out-of-band unload of the model here from
                 // the model server process, model-mesh isn't aware of
                 ManagedChannel mrChannel = NettyChannelBuilder.forAddress("localhost", 9000 + 2).usePlaintext().build();
-                // This should really be ModelRuntimeBlockingStub but the test impl uses the legacy service name
-                ModelServerBlockingStub mrStub = ModelServerGrpc.newBlockingStub(mrChannel);
+                ModelRuntimeGrpc.ModelRuntimeBlockingStub mrStub = ModelRuntimeGrpc.newBlockingStub(mrChannel);
                 // This is a blocking call, if it doesn't throw then the unload was successful.
                 try {
                     mrStub.unloadModel(UnloadModelRequest.newBuilder().setModelId("myModel").build());

--- a/src/test/java/com/ibm/watson/modelmesh/example/ExampleModelRuntime.java
+++ b/src/test/java/com/ibm/watson/modelmesh/example/ExampleModelRuntime.java
@@ -17,22 +17,14 @@
 package com.ibm.watson.modelmesh.example;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.ibm.watson.modelmesh.api.LoadModelRequest;
-import com.ibm.watson.modelmesh.api.LoadModelResponse;
-import com.ibm.watson.modelmesh.api.ModelSizeRequest;
-import com.ibm.watson.modelmesh.api.ModelSizeResponse;
-import com.ibm.watson.modelmesh.api.RuntimeStatusRequest;
-import com.ibm.watson.modelmesh.api.RuntimeStatusResponse;
+import com.ibm.watson.modelmesh.api.*;
 import com.ibm.watson.modelmesh.api.RuntimeStatusResponse.MethodInfo;
 import com.ibm.watson.modelmesh.api.RuntimeStatusResponse.Status;
-import com.ibm.watson.modelmesh.api.UnloadModelRequest;
-import com.ibm.watson.modelmesh.api.UnloadModelResponse;
 import com.ibm.watson.modelmesh.example.api.ExamplePredictorGrpc.ExamplePredictorImplBase;
 import com.ibm.watson.modelmesh.example.api.Predictor.CategoryAndConfidence;
 import com.ibm.watson.modelmesh.example.api.Predictor.MultiPredictResponse;
 import com.ibm.watson.modelmesh.example.api.Predictor.PredictRequest;
 import com.ibm.watson.modelmesh.example.api.Predictor.PredictResponse;
-import com.ibm.watson.tas.internal.proto.ModelServerGrpc.ModelServerImplBase;
 import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.Metadata;
@@ -62,7 +54,7 @@ import static java.lang.Integer.parseInt;
 /**
  * An example Model Serving runtime for use with the model-mesh framework
  */
-public class ExampleModelRuntime extends ModelServerImplBase {
+public class ExampleModelRuntime extends ModelRuntimeGrpc.ModelRuntimeImplBase { // ModelServerImplBase {
 
     public static final boolean FAST_MODE = !"false".equals(System.getenv("FAST_MODE"));
 


### PR DESCRIPTION
#### Motivation

By default, model-mesh transparently forwards any gRPC service requests to back-end runtimes based on model id headers. These calls will work as long as the runtime implements the target service method. However, runtimes might also expose the internal model management methods on the same port and these are intended for model-mesh's internal use only. Currently they could be accessed directly from the outside in this case which could pose a security risk.

It's already possible to lock down which service methods are permitted at both the inside and outside service boundaries, but there's legitimate cases where it's more convenient to allow any methods and just have the runtime reject if unimplemented. So we should unconditionally block internal management service methods (with service name `mmesh.ModelRuntime`).

#### Modification

- Check whether service name prefix of f.q. method name matches the forbidden one and reject the request if so
- Add unit test for this case

#### Result

Avoid direct access to internal service methods

Signed-off-by: Nick Hill <nickhill@us.ibm.com>