### PR TITLE
chore: Update dependencies including jackson CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,13 +63,13 @@
     <kv-utils-version>0.5.0</kv-utils-version>
     <etcd-java-version>0.0.19</etcd-java-version>
     <protobuf-version>3.19.4</protobuf-version>
-    <annotation-version>9.0.59</annotation-version>
+    <annotation-version>9.0.60</annotation-version>
     <guava-version>31.1-jre</guava-version>
-    <jackson-databind-version>2.13.2</jackson-databind-version>
-    <gson-version>2.8.9</gson-version>
+    <jackson-databind-version>2.13.2.1</jackson-databind-version>
+    <gson-version>2.9.0</gson-version>
     <eclipse-collections-version>11.0.0</eclipse-collections-version>
     <log4j2-version>2.17.2</log4j2-version>
-    <slf4j-version>1.7.32</slf4j-version>
+    <slf4j-version>1.7.36</slf4j-version>
     <!-- Care must be taken when updating the prometheus client lib version
          since we have some custom optimized extensions to this -->
     <prometheus-version>0.9.0</prometheus-version>


### PR DESCRIPTION
jackson-databind `3.13.2.1` fixes CVE-2020-36518

Signed-off-by: Nick Hill <nickhill@us.ibm.com>