### PR TITLE
deps: Update grpc, netty, protobuf dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,12 @@
     <!--suppress UnresolvedMavenProperty -->
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
-    <grpc-version>1.45.1</grpc-version>
-    <netty-version>4.1.75.Final</netty-version>
+    <grpc-version>1.46.0</grpc-version>
+    <netty-version>4.1.76.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.0</kv-utils-version>
     <etcd-java-version>0.0.20</etcd-java-version>
-    <protobuf-version>3.20.0</protobuf-version>
+    <protobuf-version>3.20.1</protobuf-version>
     <annotation-version>9.0.62</annotation-version>
     <guava-version>31.1-jre</guava-version>
     <jackson-databind-version>2.13.2.2</jackson-databind-version>


### PR DESCRIPTION
- grpc-java `1.46.0`
- netty `4.1.46.Final`
- protobuf `3.20.1`

Signed-off-by: Nick Hill <nickhill@us.ibm.com>