### PR TITLE
feat: Add metrics for inference request/response payload sizes

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/Metric.java
+++ b/src/main/java/com/ibm/watson/modelmesh/Metric.java
@@ -31,9 +31,15 @@ enum Metric {
     INVOKE_MODEL_TIME("invoke-", "modelmesh_invoke_model_milliseconds", TIMING_HISTO,
             "Internal model server inference request time"),
     API_REQUEST_COUNT("api-", "modelmesh_api_request", COUNTER_WITH_HISTO, //TODO _total suffix TBD
-            "Count of external inference requets"),
+            "Count of external inference requests"),
     API_REQUEST_TIME("api-", "modelmesh_api_request_milliseconds", TIMING_HISTO,
             "External inference request time"),
+
+    // payload
+    REQUEST_PAYLOAD_SIZE("reqSize-", "modelmesh_request_size_bytes", MESSAGE_SIZE_HISTO,
+            "Inference request payload size"),
+    RESPONSE_PAYLOAD_SIZE("respSize-", "modelmesh_response_size_bytes", MESSAGE_SIZE_HISTO,
+            "Inference response payload size"),
 
     CACHE_MISS("cacheMiss", "modelmesh_cache_miss", COUNTER_WITH_HISTO,
             "Count of inference request cache misses"),
@@ -71,7 +77,7 @@ enum Metric {
             "Time since model was last used when evicted"),
 
     // size (bytes)
-    LOADED_MODEL_SIZE("mmModelSizeBytes", "modelmesh_loaded_model_size_bytes", SIZE_HISTO,
+    LOADED_MODEL_SIZE("mmModelSizeBytes", "modelmesh_loaded_model_size_bytes", MODEL_SIZE_HISTO,
             "Reported size of loaded model"),
 
 
@@ -137,6 +143,7 @@ enum Metric {
         GAUGE,
         TIMING_HISTO,
         AGE_HISTO,
-        SIZE_HISTO
+        MODEL_SIZE_HISTO,
+        MESSAGE_SIZE_HISTO
     }
 }

--- a/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
@@ -138,7 +138,6 @@ import java.util.stream.Stream;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.ibm.watson.kvutils.KVTable.EventType.*;
-import static com.ibm.watson.modelmesh.GrpcSupport.newInterruptingListener;
 import static com.ibm.watson.modelmesh.ModelLoader.UNIT_SIZE;
 import static com.ibm.watson.modelmesh.ModelMeshEnvVars.*;
 import static com.ibm.watson.modelmesh.SidecarModelMesh.trimStack;
@@ -3931,8 +3930,8 @@ public abstract class ModelMesh extends ThriftService
         } finally {
             if (methodStartNanos > 0L && metrics.isEnabled()) {
                 // only logged here in non-grpc (legacy) mode
-                metrics.logApplyMethodTookNanosMetric(true, getRequestMethodName(method, args),
-                        nanoTime() - methodStartNanos, metricStatusCode);
+                metrics.logRequestMetrics(true, getRequestMethodName(method, args),
+                        nanoTime() - methodStartNanos, metricStatusCode, -1, -1);
             }
             curThread.setName(threadNameBefore);
         }
@@ -4460,7 +4459,8 @@ public abstract class ModelMesh extends ThriftService
             long tookNanos = nanoTime() - beforeNanos;
             ce.afterInvoke(weight, tookNanos);
             if (code != null && metrics.isEnabled()) {
-                metrics.logApplyMethodTookNanosMetric(false, getRequestMethodName(method, args), tookNanos, code);
+                metrics.logRequestMetrics(false, getRequestMethodName(method, args),
+                        tookNanos, code, -1, -1);
             }
         }
     }

--- a/src/main/java/com/ibm/watson/prometheus/NettyServer.java
+++ b/src/main/java/com/ibm/watson/prometheus/NettyServer.java
@@ -89,6 +89,7 @@ public class NettyServer implements Closeable {
         logger.info("Starting prometheus " + (tls ? "HTTPS" : "HTTP") + " server on port " + port);
         final SslContext sslContext;
         if (tls) {
+            // Note this requires bouncycastle library for java versions >= 15
             SelfSignedCertificate cert = new SelfSignedCertificate();
             sslContext = SslContextBuilder.forServer(cert.key(), cert.cert())
                 .sslProvider(OpenSsl.isAvailable() ? SslProvider.OPENSSL : SslProvider.JDK).build();

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ibm.watson.modelmesh;
+
+import com.google.common.collect.ImmutableMap;
+import com.ibm.watson.modelmesh.api.GetStatusRequest;
+import com.ibm.watson.modelmesh.api.ModelInfo;
+import com.ibm.watson.modelmesh.api.ModelMeshGrpc;
+import com.ibm.watson.modelmesh.api.ModelMeshGrpc.ModelMeshBlockingStub;
+import com.ibm.watson.modelmesh.api.ModelStatusInfo;
+import com.ibm.watson.modelmesh.api.ModelStatusInfo.ModelStatus;
+import com.ibm.watson.modelmesh.api.RegisterModelRequest;
+import com.ibm.watson.modelmesh.api.UnregisterModelRequest;
+import com.ibm.watson.modelmesh.example.api.ExamplePredictorGrpc;
+import com.ibm.watson.modelmesh.example.api.ExamplePredictorGrpc.ExamplePredictorBlockingStub;
+import com.ibm.watson.modelmesh.example.api.Predictor.PredictRequest;
+import com.ibm.watson.modelmesh.example.api.Predictor.PredictResponse;
+import io.grpc.ManagedChannel;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Model-mesh unit tests
+ */
+public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
+
+    @Override
+    protected int replicaCount() {
+        return 1;
+    }
+
+    protected int requestCount() {
+        return 30;
+    }
+
+    static final int METRICS_PORT = 2112;
+
+    static final String SCHEME = "https"; // or http
+
+    @Override
+    protected Map<String, String> extraEnvVars() {
+        return  ImmutableMap.of("MM_METRICS", "prometheus:port=" + METRICS_PORT + ";scheme=" + SCHEME);
+    }
+
+    @Test
+    public void metricsTest() throws Exception {
+
+        ManagedChannel channel = NettyChannelBuilder.forAddress("localhost", 9000).usePlaintext().build();
+        try {
+            ModelMeshBlockingStub manageModels = ModelMeshGrpc.newBlockingStub(channel);
+
+            ExamplePredictorBlockingStub useModels = ExamplePredictorGrpc.newBlockingStub(channel);
+
+            // verify not found status
+            ModelStatusInfo status = manageModels.getModelStatus(GetStatusRequest.newBuilder()
+                    .setModelId("i don't exist").build());
+
+            assertEquals(ModelStatus.NOT_FOUND, status.getStatus());
+            assertEquals(0, status.getErrorsCount());
+
+            // add a model
+            String modelId = "myModel";
+            ModelStatusInfo statusInfo = manageModels.registerModel(RegisterModelRequest.newBuilder()
+                    .setModelId(modelId).setModelInfo(ModelInfo.newBuilder().setType("ExampleType").build())
+                    .setLoadNow(true).build());
+
+            System.out.println("registerModel returned: " + statusInfo.getStatus());
+
+            // call predict a bunch of times on the model
+            PredictRequest req = PredictRequest.newBuilder().setText("predict me!").build();
+
+            System.out.println("Calling predict many times with small payload");
+            long before = System.nanoTime();
+            for (int i = 0; i < requestCount(); i++) {
+                PredictResponse response = forModel(useModels, modelId).predict(req);
+                assertEquals(1.0, response.getResults(0).getConfidence(), 0);
+                assertEquals("classification for predict me! by model myModel",
+                        response.getResults(0).getCategory());
+            }
+            System.out.println("Took " + (System.nanoTime() - before) / 1000_000_000L + "sec");
+
+            // verify getStatus
+            status = manageModels.getModelStatus(GetStatusRequest.newBuilder()
+                    .setModelId(modelId).build());
+
+            assertEquals(ModelStatus.LOADED, status.getStatus());
+            assertEquals(0, status.getErrorsCount());
+
+            System.out.println("Calling predict 10 times with larger payload");
+            // verify larger payload
+            int bigChars = 2_000_000;
+            StringBuilder sb = new StringBuilder(bigChars);
+            for (int i = 0; i < bigChars; i++) {
+                sb.append('a');
+            }
+            String toSend = sb.toString();
+            req = PredictRequest.newBuilder().setText(toSend).build();
+
+            for (int i = 0; i < 10; i++) {
+                PredictResponse response = forModel(useModels, modelId)
+                        .withDeadlineAfter(2, TimeUnit.SECONDS).predict(req);
+                assertEquals("classification for " + toSend + " by model myModel",
+                        response.getResults(0).getCategory());
+            }
+
+            // grab and verify prometheus metrics
+            verifyMetrics();
+
+            // delete
+            manageModels.unregisterModel(UnregisterModelRequest.newBuilder()
+                    .setModelId(modelId).build());
+        } finally {
+            channel.shutdown();
+        }
+    }
+
+    public void verifyMetrics() throws Exception {
+        // Insecure trust manager - skip TLS verification
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, InsecureTrustManagerFactory.INSTANCE.getTrustManagers(), null);
+
+        HttpClient client = HttpClient.newBuilder().sslContext(sslContext).build();
+        HttpRequest metricsRequest = HttpRequest.newBuilder()
+                .uri(URI.create(SCHEME + "://localhost:" + METRICS_PORT + "/metrics")).build();
+
+        HttpResponse<Stream<String>> resp = client.send(metricsRequest, HttpResponse.BodyHandlers.ofLines());
+
+        assertEquals(200, resp.statusCode());
+
+        //resp.body().forEach(System.out::println);
+
+        Map<String,Double> metrics = resp.body().filter(s -> !s.startsWith("#")).map(s -> s.split("\\s+"))
+                    .collect(Collectors.toMap(t -> t[0], t -> Double.parseDouble(t[1])));
+
+        System.out.println(metrics.size() + " metrics scraped");
+
+        // Spot check some expected metrics and values
+
+        // External response time should all be < 2000ms (includes cache hit loading time)
+        assertEquals(40.0, metrics.get("modelmesh_api_request_milliseconds_bucket{method=\"predict\",code=\"OK\",le=\"2000.0\",}"));
+        // External response time should all be < 200ms (includes cache hit loading time)
+        assertEquals(40.0, metrics.get("modelmesh_invoke_model_milliseconds_bucket{method=\"predict\",code=\"OK\",le=\"200.0\",}"));
+        // Simulated model sizing time is < 200ms
+        assertEquals(1.0, metrics.get("modelmesh_model_sizing_milliseconds_bucket{le=\"200.0\",}"));
+        // Simulated model sizing time is > 50ms
+        assertEquals(0.0, metrics.get("modelmesh_model_sizing_milliseconds_bucket{le=\"50.0\",}"));
+        // Simulated model size is between 64MiB and 256MiB
+        assertEquals(0.0, metrics.get("modelmesh_loaded_model_size_bytes_bucket{le=\"6.7108864E7\",}"));
+        assertEquals(1.0, metrics.get("modelmesh_loaded_model_size_bytes_bucket{le=\"2.68435456E8\",}"));
+        // One model is loaded
+        assertEquals(1.0, metrics.get("modelmesh_models_loaded_total"));
+        assertEquals(1.0, metrics.get("modelmesh_instance_models_total"));
+        // Histogram counts should reflect the two payload sizes (30 small, 10 large)
+        assertEquals(30.0, metrics.get("modelmesh_request_size_bytes_bucket{method=\"predict\",code=\"OK\",le=\"128.0\",}"));
+        assertEquals(40.0, metrics.get("modelmesh_request_size_bytes_bucket{method=\"predict\",code=\"OK\",le=\"2097152.0\",}"));
+        assertEquals(30.0, metrics.get("modelmesh_response_size_bytes_bucket{method=\"predict\",code=\"OK\",le=\"128.0\",}"));
+        assertEquals(40.0, metrics.get("modelmesh_response_size_bytes_bucket{method=\"predict\",code=\"OK\",le=\"2097152.0\",}"));
+    }
+
+}


### PR DESCRIPTION
#### Motivation

Model-mesh already exposes a number of useful metrics but it would be useful to also monitor the size of requests and responses.

#### Modification

- Add new `modelmesh_request_size_bytes` and `modelmesh_response_size_bytes` metrics which use a new `MESSAGE_SIZE_HISTO` histogram definition with buckets more suited to typical message sizes
- Generalize existing `logApplyMethodTookNanosMetric()` method to log all request-specific metrics (including these new ones) and rename to `logRequestMetrics()`
- Change current behaviour where prometheus request metrics were not logged for non-success response codes
- Add basic unit test for prometheus metrics

#### Result

Request and response payload sizes can be easily tracked along with other operational metrics.
