### PR TITLE
logs: Some logging improvements for better problem diagnosis

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/InstanceRecord.java
+++ b/src/main/java/com/ibm/watson/modelmesh/InstanceRecord.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ibm.watson.kvutils.KVRecord;
+import com.ibm.watson.modelmesh.TypeConstraintManager.ProhibitedTypeSet;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -69,7 +70,7 @@ public class InstanceRecord extends KVRecord {
 
     // This is set only when type constraints are in use
     @JsonIgnore
-    transient volatile String[] prohibitedTypes;
+    transient volatile ProhibitedTypeSet prohibitedTypes;
 
     InstanceRecord() { // just for jackson defaults resolution
         this(0, 0, null, null, NO_LABELS);

--- a/src/main/java/com/ibm/watson/modelmesh/InstanceSetStatsTracker.java
+++ b/src/main/java/com/ibm/watson/modelmesh/InstanceSetStatsTracker.java
@@ -17,6 +17,7 @@
 package com.ibm.watson.modelmesh;
 
 import com.ibm.watson.modelmesh.ModelMesh.ClusterStats;
+import com.ibm.watson.modelmesh.TypeConstraintManager.ProhibitedTypeSet;
 
 import java.util.function.LongPredicate;
 
@@ -32,7 +33,7 @@ final class InstanceSetStatsTracker {
     static final ClusterStats EMPTY_STATS = new ClusterStats(0L, 0L, Long.MAX_VALUE, 0, 0);
 
     private final LongPredicate isFull;
-    final String[] prohibitedTypesSet;
+    final ProhibitedTypeSet prohibitedTypesSet;
 
     private long totalCapacity = 0, totalFree = 0, lru = Long.MAX_VALUE;
     private int count = 0, modelCount = 0;
@@ -40,7 +41,7 @@ final class InstanceSetStatsTracker {
     //TODO getter maybe
     volatile ClusterStats currentStats = EMPTY_STATS;
 
-    public InstanceSetStatsTracker(String[] prohibitedTypesSet, LongPredicate isFull) {
+    public InstanceSetStatsTracker(ProhibitedTypeSet prohibitedTypesSet, LongPredicate isFull) {
         this.prohibitedTypesSet = prohibitedTypesSet;
         this.isFull = isFull;
     }

--- a/src/main/java/com/ibm/watson/modelmesh/Utils.java
+++ b/src/main/java/com/ibm/watson/modelmesh/Utils.java
@@ -22,20 +22,17 @@ public final class Utils {
 
     private Utils() {}
 
-    public static final Comparator<String[]> STRING_ARRAY_COMP = new Comparator<String[]>() {
-        @Override
-        public int compare(String[] l1, String[] l2) {
-            int diff = l1.length - l2.length;
-            if (diff != 0) {
+    public static final Comparator<String[]> STRING_ARRAY_COMP = (l1, l2) -> {
+        int diff = l1.length - l2.length;
+        if (diff != 0) {
+            return diff;
+        }
+        for (int i = 0; i < l1.length; i++) {
+            if ((diff = l1[i].compareTo(l2[i])) != 0) {
                 return diff;
             }
-            for (int i = 0; i < l1.length; i++) {
-                if ((diff = l1[i].compareTo(l2[i])) != 0) {
-                    return diff;
-                }
-            }
-            return 0;
         }
+        return 0;
     };
 
     public static <T> boolean empty(T[] arr) {


### PR DESCRIPTION
#### Motivation

Some places in the modelmesh logs could do with additional information to help with debugging problems at runtime.

#### Modifications

- Small refactor of "prohibited type sets" used in the type constraint logic to use a dedicated immutable class rather than raw string array
- Include hex hashcode in its `toString` output so that distinguishing distinct PTSs in log output is easier
- Log a warning with relevant diagnostic info when a model load is blocked for some reason other than loading failure

#### Result

Slightly clearer code, easier diagnosis of runtime problems in some cases.

Signed-off-by: Nick Hill <nickhill@us.ibm.com>