### PR TITLE
fix: Switch to use G1 garbage collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ COPY --from=build /build/target/dockerhome/ /opt/kserve/mmesh/
 # Make this the current directory when starting the container
 WORKDIR /opt/kserve/mmesh
 
-RUN microdnf install shadow-utils python39 && \
+RUN microdnf install shadow-utils hostname python39 && \
     # Create app user
     useradd -c "Application User" -U -u ${USER} -m app && \
     chown -R app:0 /home/app && \
@@ -114,5 +114,4 @@ EXPOSE 8080
 USER ${USER}
 
 # The command to run by default when the container is first launched
-# Use scl_source to ensure PATH and other env vars are set up correctly with UBI python3 locations
 CMD ["sh", "-c", "exec /opt/kserve/mmesh/start.sh"]

--- a/src/main/scripts/start.sh
+++ b/src/main/scripts/start.sh
@@ -398,8 +398,8 @@ fi
 # print command that's about to be run
 set -x
 
-exec $JAVA_HOME/bin/java -cp "$LL_JAR:lib/*" -XX:+UnlockExperimentalVMOptions -XX:+UseConcMarkSweepGC \
- -XX:+CMSConcurrentMTEnabled -XX:GCTimeRatio=10 -XX:MaxGCPauseMillis=${MAX_GC_PAUSE} \
+exec $JAVA_HOME/bin/java -cp "$LL_JAR:lib/*" -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC \
+ -XX:MaxGCPauseMillis=${MAX_GC_PAUSE} \
  -XX:-ResizePLAB -Xmx${HEAP_SIZE_MB}m -Xms${HEAP_SIZE_MB}m \
  ${STRING_SCALE_JVM_ARGS} \
  -XX:MaxInlineLevel=28 \


### PR DESCRIPTION
#### Motivation

ModelMesh previously used the Concurrent Mark Sweep (CMS) garbage collector, chosen based on tuning done some time ago. The CMS collector was removed in Java 14 so can't be used now that we have moved to Java 17.

#### Modification

- Revert container start script to start modelmesh with the G1 garbage collector
- Ensure hostname command is available in container (used by start script in non-Kubernetes case)

We may later switch to a different collector such as Shenandoah, depending on results of performance comparisons.

#### Result

ModelMesh container image works again