### PR TITLE
feat: Rework second-copy scaling logic

### DIFF
--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshEvictionsTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshEvictionsTest.java
@@ -94,6 +94,11 @@ public class ModelMeshEvictionsTest {
         initializeTasStandaloneZookeeperTables();
 
         System.setProperty("tas.janitor_freq_secs", "2");
+        // Shorten rate tracking task frequency from 10 sec to 100ms
+        System.setProperty("tas.ratecheck_freq_ms", "100");
+        // Increase autoscale threshold - to effectively disable
+        // load-based autoscaling logic when testing second-copy add behaviour
+        System.setProperty("MM_SCALEUP_RPM_THRESHOLD", "100000");
 
         //cluster mode
         createTasCluster();
@@ -400,7 +405,8 @@ public class ModelMeshEvictionsTest {
     }
 
     @Test
-    public void testMultiCopies() throws Exception {
+    @Timeout(value = 40, unit = TimeUnit.SECONDS)
+    public void testSecondCopyTrigger() throws Exception {
         String modelId = "mymodel";
         ModelInfo modelInfo = new ModelInfo(serviceType, modelPath);
         assertEquals(Status.LOADED, clusterClient.addModel(modelId, modelInfo, true, true).getStatus());
@@ -408,21 +414,44 @@ public class ModelMeshEvictionsTest {
         // only one copy gets loaded during the add
         assertEquals(1, clusterRegistry.get(modelId).getInstanceIds().size());
 
+        // With the rateTrackingTask frequency reduced to 100ms, a second copy
+        // will be triggered if there are two usages of the model more than 4.2
+        // but less than 24 second apart
+
+        // Small sleep to ensure the rateTracking task is running post-startup
+        Thread.sleep(60);
         clusterClient.applyModel(modelId, null, null);
-        Set<String> instances = new HashSet<>();
-        Thread.sleep(3000L);
-        // this "usage" should trigger a second copy to be loaded
+        Thread.sleep(1000L);
+        // After a single use, should still be a single copy
+        assertCopyCount(modelId, 1);
         clusterClient.applyModel(modelId, null, null);
-        Thread.sleep(3000L);
-        for (int i = 0; i < 8; i++) {
-            instances.add(StandardCharsets.UTF_8.decode(
-                    clusterClient.applyModel(modelId, null, null)).toString());
-        }
-        assertEquals(2, instances.size());
-        assertEquals(2, clusterRegistry.get(modelId).getInstanceIds().size());
+        Thread.sleep(500L);
+        // Next usage is only 1 sec after first usage, so should remain as 1 copy
+        assertCopyCount(modelId, 1);
+        Thread.sleep(25_000);
+        clusterClient.applyModel(modelId, null, null);
+        Thread.sleep(500L);
+        // More than 25 sec later crosses max interval threshold,
+        // also should not trigger yet
+        assertCopyCount(modelId, 1);
+        Thread.sleep(4000L);
+        clusterClient.applyModel(modelId, null, null);
+        Thread.sleep(500L);
+        // latest use had another usage of the model 4.5 seconds prior which is
+        // within the [4.5, 24] sec range and hence should trigger the second copy
+        assertCopyCount(modelId, 2);
         clusterClient.deleteModel(modelId);
     }
 
+    void assertCopyCount(String modelId, int expected) throws Exception {
+        Set<String> instances = new HashSet<>();
+        for (int i = 0; i < (expected * 4); i++) {
+            instances.add(StandardCharsets.UTF_8.decode(
+                    clusterClient.applyModel(modelId, null, null)).toString());
+        }
+        assertEquals(expected, instances.size());
+        assertEquals(expected, clusterRegistry.get(modelId).getInstanceIds().size());
+    }
 
     @AfterEach
     public void afterEachTest() {


### PR DESCRIPTION
#### Motivation

Model-mesh will currently ensure that there's two copies of any model which has been used "recently" to make them "HA" and minimize the chance of disruption if a single pod dies. However this has recently proved problematic in one case involving a periodic invocation of a large number of models (for example once per day). Second copies of all are loaded within a small timeframe, filling the cache and evicting other recently-used models. In this case there's little value in having second copies since the usage is isolated.

A better heuristic is needed for deciding when redundant copies should be added.

#### Modifications

- Remove the current logic related to second-copy triggering. This includes methods invoked on the inference request path and from the regular janitor task.
- Piggy-back on the existing frequent rate-tracking task to keep track of "iteration numbers" in which single-copy models are loaded, and only trigger a second copy when there's a prior usage more than 7 minutes but less than 40 minutes ago. If the usage is confined to a < 7min window it could be isolated; if > 40min apart the value of a second copy is lower (probability of pod death causing disruption is minimal).
- By-pass the second-copy triggering altogether if the cache is full and LRU is low
- More aggressively scale down second copies for inactive models, especially if the cache is full / LRU recent
- Update unit test to reflect new behaviour

#### Result

More effective use of available model cache space, which should result in lower model memory requirement for many use cases.

Note that this does not affect auto-scaling behaviour based on request load. A single copy may now scale up immediately if subjected to sufficient load independent of the aforementioned redundant copy logic.

Signed-off-by: Nick Hill <nickhill@us.ibm.com>