### PR TITLE
Change PreStop endpoint to no longer be exposed outside the pod

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/RuntimeContainersPreStopServer.java
+++ b/src/main/java/com/ibm/watson/modelmesh/RuntimeContainersPreStopServer.java
@@ -135,7 +135,7 @@ class RuntimeContainersPreStopServer implements Closeable {
                     }
                 });
 
-        return b.bind(port).channel();
+        return b.bind("127.0.0.1", port).channel();
     }
 
     @Override


### PR DESCRIPTION
#### Motivation

The server for the `/prestop` endpoint on port 8090 is currently listening on the default address 0.0.0.0, which makes it accessible outside the pod. The endpoint is only intended for Kubernetes' lifecycle hooks, so it should be listening on address 127.0.0.1 instead.

#### Modifications

The endpoint now listens only on localhost. I've explicitly used 127.0.0.1 to make sure it's listening on the IPv4 localhost.

#### Result

The endpoint is no longer exposed outside the pod.

Since this no longer allows the lifecycle hook to use a httpGet action, I'm also submitting a pull request to change it to an exec action: https://github.com/kserve/modelmesh-serving/pull/208