### PR TITLE
feat: Expose detailed JVM and netty memory metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,12 +328,6 @@
       <artifactId>simpleclient_common</artifactId>
       <version>${prometheus-version}</version>
     </dependency>
-    <!-- Prometheus metrics Hotspot JVM metrics-->
-    <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_hotspot</artifactId>
-      <version>${prometheus-version}</version>
-    </dependency>
 
     <dependency>
       <!-- used only for int list, dep can easily be removed if necessary -->

--- a/src/main/java/com/ibm/watson/prometheus/NettyMemoryExports.java
+++ b/src/main/java/com/ibm/watson/prometheus/NettyMemoryExports.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ibm.watson.prometheus;
+
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocatorMetric;
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Exports netty pooled bytebuf allocation/usage metrics
+ */
+public final class NettyMemoryExports extends Collector {
+
+    private static final List<String> AREA_LABEL = Collections.singletonList("area");
+    private static final List<String> HEAP = Collections.singletonList("heap");
+    private static final List<String> DIRECT = Collections.singletonList("direct");
+
+    private final PooledByteBufAllocator allocator;
+
+    public NettyMemoryExports() {
+        this(PooledByteBufAllocator.DEFAULT);
+    }
+
+    NettyMemoryExports(PooledByteBufAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    public List<MetricFamilySamples> collect() {
+        final GaugeMetricFamily allocMem = new GaugeMetricFamily(
+                "netty_pool_mem_allocated_bytes",
+                "Amount of memory allocated to netty buffer pools.",
+                AREA_LABEL);
+        final PooledByteBufAllocatorMetric metric = allocator.metric();
+        allocMem.addMetric(HEAP, metric.usedHeapMemory());
+        allocMem.addMetric(DIRECT, metric.usedDirectMemory());
+
+        final GaugeMetricFamily usedMem = new GaugeMetricFamily(
+                "netty_pool_mem_used_bytes",
+                "Amount of netty pool memory allocated to app buffers.",
+                AREA_LABEL);
+        usedMem.addMetric(HEAP, allocator.pinnedHeapMemory());
+        usedMem.addMetric(DIRECT, allocator.pinnedDirectMemory());
+
+        return Arrays.asList(allocMem, usedMem);
+    }
+}

--- a/src/main/java/com/ibm/watson/prometheus/hotspot/BufferPoolsExports.java
+++ b/src/main/java/com/ibm/watson/prometheus/hotspot/BufferPoolsExports.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This is a modified (optimized) version of the equivalent class from the official
+ * Apache 2.0 licensed prometheus java client https://github.com/prometheus/client_java,
+ * which is also a dependency.
+ *
+ * The current mods are based on version 0.9.0
+ */
+package com.ibm.watson.prometheus.hotspot;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Exports metrics about JVM buffers.
+ *
+ */
+public final class BufferPoolsExports extends Collector {
+
+    private static final List<String> POOL_LABEL = Collections.singletonList("pool");
+
+    private final BufferPoolMXBean[] bufferPoolMXBeans;
+    private final List<String>[] poolBeanNames;
+
+    public BufferPoolsExports() {
+        final List<BufferPoolMXBean> poolBeans = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class);
+        this.bufferPoolMXBeans = poolBeans.toArray(BufferPoolMXBean[]::new);
+        this.poolBeanNames = poolBeans.stream().map(pb ->
+                Collections.singletonList(pb.getName())).toArray(List[]::new);
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        GaugeMetricFamily used = new GaugeMetricFamily(
+                "jvm_buffer_pool_used_bytes",
+                "Used bytes of a given JVM buffer pool.",
+                POOL_LABEL);
+        GaugeMetricFamily capacity = new GaugeMetricFamily(
+                "jvm_buffer_pool_capacity_bytes",
+                "Bytes capacity of a given JVM buffer pool.",
+                POOL_LABEL);
+        GaugeMetricFamily buffers = new GaugeMetricFamily(
+                "jvm_buffer_pool_used_buffers",
+                "Used buffers of a given JVM buffer pool.",
+                POOL_LABEL);
+        for (int i = 0; i < bufferPoolMXBeans.length; i++) {
+            final List<String> poolName = poolBeanNames[i];
+            final BufferPoolMXBean pool = bufferPoolMXBeans[i];
+            used.addMetric(poolName, pool.getMemoryUsed());
+            capacity.addMetric(poolName, pool.getTotalCapacity());
+            buffers.addMetric(poolName, pool.getCount());
+        }
+        return Arrays.asList(used, capacity, buffers);
+    }
+}

--- a/src/main/java/com/ibm/watson/prometheus/hotspot/GarbageCollectorExports.java
+++ b/src/main/java/com/ibm/watson/prometheus/hotspot/GarbageCollectorExports.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This is a modified (optimized) version of the equivalent class from the official
+ * Apache 2.0 licensed prometheus java client https://github.com/prometheus/client_java,
+ * which is also a dependency.
+ *
+ * The current mods are based on version 0.9.0
+ */
+package com.ibm.watson.prometheus.hotspot;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.SummaryMetricFamily;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Exports metrics about JVM garbage collectors.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new GarbageCollectorExports().register();
+ * }
+ * </pre>
+ * Example metrics being exported:
+ * <pre>
+ *   jvm_gc_collection_seconds_count{gc="PS1"} 200
+ *   jvm_gc_collection_seconds_sum{gc="PS1"} 6.7
+ * </pre>
+ */
+public final class GarbageCollectorExports extends Collector {
+
+    private static final List<String> GC_LABEL = Collections.singletonList("gc");
+
+    private final GarbageCollectorMXBean[] garbageCollectors;
+    private final List<String>[] garbageCollectorNames;
+
+    public GarbageCollectorExports() {
+        this(ManagementFactory.getGarbageCollectorMXBeans());
+    }
+
+    GarbageCollectorExports(List<GarbageCollectorMXBean> garbageCollectors) {
+        this.garbageCollectors = garbageCollectors.toArray(GarbageCollectorMXBean[]::new);
+        this.garbageCollectorNames = garbageCollectors.stream().map(gc ->
+                Collections.singletonList(gc.getName())).toArray(List[]::new);
+    }
+
+    public List<MetricFamilySamples> collect() {
+        SummaryMetricFamily gcCollection = new SummaryMetricFamily(
+                "jvm_gc_collection_seconds",
+                "Time spent in a given JVM garbage collector in seconds.",
+                GC_LABEL);
+        for (int i = 0; i < garbageCollectors.length; i++) {
+            final GarbageCollectorMXBean gc = garbageCollectors[i];
+            gcCollection.addMetric(garbageCollectorNames[i],
+                    gc.getCollectionCount(),
+                    gc.getCollectionTime() / MILLISECONDS_PER_SECOND);
+        }
+        return Collections.singletonList(gcCollection);
+    }
+}

--- a/src/main/java/com/ibm/watson/prometheus/hotspot/MemoryAllocationExports.java
+++ b/src/main/java/com/ibm/watson/prometheus/hotspot/MemoryAllocationExports.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This is a modified (optimized) version of the equivalent class from the official
+ * Apache 2.0 licensed prometheus java client https://github.com/prometheus/client_java,
+ * which is also a dependency.
+ *
+ * The current mods are based on version 0.9.0
+ */
+package com.ibm.watson.prometheus.hotspot;
+
+import com.ibm.watson.prometheus.Counter;
+import com.sun.management.GarbageCollectionNotificationInfo;
+import com.sun.management.GcInfo;
+import io.prometheus.client.Collector;
+
+import javax.management.Notification;
+import javax.management.NotificationEmitter;
+import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryUsage;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class MemoryAllocationExports extends Collector {
+    private final Counter allocatedCounter = Counter.build()
+            .name("jvm_memory_pool_allocated_bytes_total")
+            .help("Total bytes allocated in a given JVM memory pool. Only updated after GC, not continuously.")
+            .labelNames("pool")
+            .create();
+
+    public MemoryAllocationExports() {
+        AllocationCountingNotificationListener listener = new AllocationCountingNotificationListener(allocatedCounter);
+        for (GarbageCollectorMXBean garbageCollectorMXBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+            if (garbageCollectorMXBean instanceof NotificationEmitter) {
+                ((NotificationEmitter) garbageCollectorMXBean).addNotificationListener(listener, null, null);
+            }
+        }
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        return allocatedCounter.collect();
+    }
+
+    static final class MemUsage {
+        long usage;
+
+        long getAndSet(long value) {
+            long before = usage;
+            usage = value;
+            return before;
+        }
+    }
+
+    static final class AllocationCountingNotificationListener implements NotificationListener {
+        private final Map<String, MemUsage> lastMemoryUsage = new HashMap<>(8);
+        private final Counter counter;
+
+        AllocationCountingNotificationListener(Counter counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public synchronized void handleNotification(Notification notification, Object handback) {
+            final GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from((CompositeData) notification.getUserData());
+            final GcInfo gcInfo = info.getGcInfo();
+            Map<String, MemoryUsage> memoryUsageBeforeGc = gcInfo.getMemoryUsageBeforeGc();
+            Map<String, MemoryUsage> memoryUsageAfterGc = gcInfo.getMemoryUsageAfterGc();
+            for (Map.Entry<String, MemoryUsage> entry : memoryUsageBeforeGc.entrySet()) {
+                final String memoryPool = entry.getKey();
+                final long before = entry.getValue().getUsed();
+                final long after = memoryUsageAfterGc.get(memoryPool).getUsed();
+                handleMemoryPool(memoryPool, before, after);
+            }
+        }
+
+        // Visible for testing
+        void handleMemoryPool(String memoryPool, long before, long after) {
+            /*
+             * Calculate increase in the memory pool by comparing memory used
+             * after last GC, before this GC, and after this GC.
+             * See ascii illustration below.
+             * Make sure to count only increases and ignore decreases.
+             * (Typically a pool will only increase between GCs or during GCs, not both.
+             * E.g. eden pools between GCs. Survivor and old generation pools during GCs.)
+             *
+             *                         |<-- diff1 -->|<-- diff2 -->|
+             * Timeline: |-- last GC --|             |---- GC -----|
+             *                      ___^__        ___^____      ___^___
+             * Mem. usage vars:    / last \      / before \    / after \
+             */
+
+            // Get last memory usage after GC and remember memory used after for next time
+            long last = getAndSet(lastMemoryUsage, memoryPool, after);
+            // Difference since last GC
+            long diff1 = before - last;
+            // Difference during this GC
+            long diff2 = after - before;
+            // Make sure to only count increases
+            if (diff1 < 0) {
+                diff1 = 0;
+            }
+            if (diff2 < 0) {
+                diff2 = 0;
+            }
+            long increase = diff1 + diff2;
+            if (increase > 0) {
+                counter.labels(memoryPool).inc(increase);
+            }
+        }
+
+        private static long getAndSet(Map<String, MemUsage> map, String key, long value) {
+            return map.computeIfAbsent(key, k -> new MemUsage()).getAndSet(value);
+        }
+    }
+}

--- a/src/main/java/com/ibm/watson/prometheus/hotspot/MemoryPoolsExports.java
+++ b/src/main/java/com/ibm/watson/prometheus/hotspot/MemoryPoolsExports.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2022 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This is a modified (optimized) version of the equivalent class from the official
+ * Apache 2.0 licensed prometheus java client https://github.com/prometheus/client_java,
+ * which is also a dependency.
+ *
+ * The current mods are based on version 0.9.0
+ */
+package com.ibm.watson.prometheus.hotspot;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.GaugeMetricFamily;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Exports metrics about JVM memory areas.
+ * <p>
+ * Example usage:
+ * <pre>
+ * {@code
+ *   new MemoryPoolsExports().register();
+ * }
+ * </pre>
+ * Example metrics being exported:
+ * <pre>
+ *   jvm_memory_bytes_used{area="heap"} 2000000
+ *   jvm_memory_bytes_committed{area="nonheap"} 200000
+ *   jvm_memory_bytes_max{area="nonheap"} 2000000
+ *   jvm_memory_pool_bytes_used{pool="PS Eden Space"} 2000
+ * </pre>
+ */
+public final class MemoryPoolsExports extends Collector {
+
+    private static final List<String> AREA_LABEL = Collections.singletonList("area");
+    private static final List<String> POOL_LABEL = Collections.singletonList("pool");
+    private static final List<String> HEAP = Collections.singletonList("heap");
+    private static final List<String> NONHEAP = Collections.singletonList("nonheap");;
+
+    private final MemoryMXBean memoryBean;
+    private final MemoryPoolMXBean[] poolBeans;
+    private final List<String>[] poolBeanNames;
+
+    public MemoryPoolsExports() {
+        this(
+                ManagementFactory.getMemoryMXBean(),
+                ManagementFactory.getMemoryPoolMXBeans());
+    }
+
+    public MemoryPoolsExports(MemoryMXBean memoryBean,
+                              List<MemoryPoolMXBean> poolBeans) {
+        this.memoryBean = memoryBean;
+        this.poolBeans = poolBeans.toArray(MemoryPoolMXBean[]::new);
+        this.poolBeanNames = poolBeans.stream().map(pb ->
+                Collections.singletonList(pb.getName())).toArray(List[]::new);
+    }
+
+    void addMemoryAreaMetrics(List<MetricFamilySamples> sampleFamilies) {
+        MemoryUsage heapUsage = memoryBean.getHeapMemoryUsage();
+        MemoryUsage nonHeapUsage = memoryBean.getNonHeapMemoryUsage();
+
+        GaugeMetricFamily used = new GaugeMetricFamily(
+                "jvm_memory_bytes_used",
+                "Used bytes of a given JVM memory area.",
+                AREA_LABEL);
+        used.addMetric(HEAP, heapUsage.getUsed());
+        used.addMetric(NONHEAP, nonHeapUsage.getUsed());
+        sampleFamilies.add(used);
+
+        GaugeMetricFamily committed = new GaugeMetricFamily(
+                "jvm_memory_bytes_committed",
+                "Committed (bytes) of a given JVM memory area.",
+                AREA_LABEL);
+        committed.addMetric(Collections.singletonList("heap"), heapUsage.getCommitted());
+        committed.addMetric(NONHEAP, nonHeapUsage.getCommitted());
+        sampleFamilies.add(committed);
+
+        GaugeMetricFamily max = new GaugeMetricFamily(
+                "jvm_memory_bytes_max",
+                "Max (bytes) of a given JVM memory area.",
+                AREA_LABEL);
+        max.addMetric(Collections.singletonList("heap"), heapUsage.getMax());
+        max.addMetric(NONHEAP, nonHeapUsage.getMax());
+        sampleFamilies.add(max);
+
+        GaugeMetricFamily init = new GaugeMetricFamily(
+                "jvm_memory_bytes_init",
+                "Initial bytes of a given JVM memory area.",
+                AREA_LABEL);
+        init.addMetric(Collections.singletonList("heap"), heapUsage.getInit());
+        init.addMetric(NONHEAP, nonHeapUsage.getInit());
+        sampleFamilies.add(init);
+    }
+
+    void addMemoryPoolMetrics(List<MetricFamilySamples> sampleFamilies) {
+        GaugeMetricFamily used = new GaugeMetricFamily(
+                "jvm_memory_pool_bytes_used",
+                "Used bytes of a given JVM memory pool.",
+                POOL_LABEL);
+        sampleFamilies.add(used);
+        GaugeMetricFamily committed = new GaugeMetricFamily(
+                "jvm_memory_pool_bytes_committed",
+                "Committed bytes of a given JVM memory pool.",
+                POOL_LABEL);
+        sampleFamilies.add(committed);
+        GaugeMetricFamily max = new GaugeMetricFamily(
+                "jvm_memory_pool_bytes_max",
+                "Max bytes of a given JVM memory pool.",
+                POOL_LABEL);
+        sampleFamilies.add(max);
+        GaugeMetricFamily init = new GaugeMetricFamily(
+                "jvm_memory_pool_bytes_init",
+                "Initial bytes of a given JVM memory pool.",
+                POOL_LABEL);
+        sampleFamilies.add(init);
+        for (int i = 0; i < poolBeans.length ; i++) {
+            final List<String> poolName = poolBeanNames[i];
+            final MemoryUsage poolUsage = poolBeans[i].getUsage();
+            used.addMetric(poolName, poolUsage.getUsed());
+            committed.addMetric(poolName, poolUsage.getCommitted());
+            max.addMetric(poolName, poolUsage.getMax());
+            init.addMetric(poolName, poolUsage.getInit());
+        }
+    }
+
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> mfs = new ArrayList<MetricFamilySamples>(8);
+        addMemoryAreaMetrics(mfs);
+        addMemoryPoolMetrics(mfs);
+        return mfs;
+    }
+}

--- a/src/main/scripts/start.sh
+++ b/src/main/scripts/start.sh
@@ -322,10 +322,6 @@ fi
 
 echo "MEM_LIMIT_MB=${MEM_LIMIT_MB}"
 
-if [ "$HEAP_SIZE" != "" ]; then
-	echo "** NOTE: HEAP_SIZE env var is deprecated, please remove it"
-fi
-
 if [ "$HEAP_SIZE_MB" = "" ]; then
     # Default heap size to MIN(41% of mem-limit, 640MiB)
     HS=$((${MEM_LIMIT_MB}*41/100))
@@ -334,14 +330,16 @@ if [ "$HEAP_SIZE_MB" = "" ]; then
 fi
 echo "HEAP_SIZE_MB=${HEAP_SIZE_MB}"
 
-# Reserved headroom for JVM internals: 64MiB + 20% of heapsize
-MEM_HEADROOM_MB=$((64+${HEAP_SIZE_MB}/5))
-echo "MEM_HEADROOM_MB=${MEM_HEADROOM_MB}"
-
 MAX_GC_PAUSE=${MAX_GC_PAUSE:-50}
 echo "MAX_GC_PAUSE=${MAX_GC_PAUSE} millisecs"
 
-MAX_DIRECT_BUFS_MB=$((${MEM_LIMIT_MB}-${HEAP_SIZE_MB}-192))
+if [ "MAX_DIRECT_BUFS_MB" = "" ]; then
+    # Reserved headroom for JVM internals: 64MiB + 8% of heapsize
+    MEM_HEADROOM_MB=$((64+8*${HEAP_SIZE_MB}/100))
+    echo "MEM_HEADROOM_MB=${MEM_HEADROOM_MB}"
+
+    MAX_DIRECT_BUFS_MB=$((${MEM_LIMIT_MB}-${HEAP_SIZE_MB}-${MEM_HEADROOM_MB}))
+fi
 echo "MAX_DIRECT_BUFS_MB=${MAX_DIRECT_BUFS_MB}"
 
 # litelinks kubernetes health probe - defaults to port 8089
@@ -373,8 +371,8 @@ NETTY_DIRECTBUF_ARGS="-Dio.netty.tryReflectionSetAccessible=true --add-opens=jav
 # this defaults to equal max heap, which can result in container OOMKilled
 MAX_DIRECT_BYTES="$((${MAX_DIRECT_BUFS_MB}*1024*1024))"
 # Java native direct memory setting shouldn't be used since all
-# direct buffers are allocated by netty, so set it small (32MiB)
-JAVA_MAXDIRECT_ARG="-XX:MaxDirectMemorySize=33554432"
+# direct buffers are allocated by netty, so set it small (20MiB)
+JAVA_MAXDIRECT_ARG="-XX:MaxDirectMemorySize=20971520"
 # This defaults to match the java setting so we set it explicitly to desired val
 NETTY_MAXDIRECT_ARG="-Dio.netty.maxDirectMemory=${MAX_DIRECT_BYTES}"
 # Ensure that grpc-java shares a single pooled buffer allocator with other netty usage (e.g. litelinks)


### PR DESCRIPTION
#### Motivation

To size model-mesh container memory allocation for different workloads, it would be useful to have more detailed usage metrics exposed.

Container process level memory usage alone is opaque and may reflect over-allocation of heap and/or direct buffer pools.

#### Modifications

- Cherry pick some of the prometheus hotspot exporters from https://github.com/prometheus/client_java/tree/main/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot, and reduce the amount of garbage they produce during collection.
- Add a netty memory exporter which includes metrics for the amount of OS memory allocated for buffer pools as well as how much of that pool capacity is currently allocated to application buffers (for both heap and direct arenas, although typically only direct should be used).
- Enable these by default when prometheus metrics are enabled, but support selective enablement via a `mem_detail=X,Y,Z` parameter in the `MM_METRICS` env var string.
- Adjust heap/direct memory sizing in start.sh to allow for explicit configuration of max direct memory size
- Adjust unit test to check for these new metrics

#### Result

More detailed memory insight/tuning possible, even in production.