### PR TITLE
chore: Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,16 +57,16 @@
     <!--suppress UnresolvedMavenProperty -->
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
-    <grpc-version>1.50.0</grpc-version>
+    <grpc-version>1.50.2</grpc-version>
     <netty-version>4.1.84.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
-    <etcd-java-version>0.0.21</etcd-java-version>
-    <protobuf-version>3.21.7</protobuf-version>
-    <annotation-version>9.0.65</annotation-version>
+    <etcd-java-version>0.0.22</etcd-java-version>
+    <protobuf-version>3.21.9</protobuf-version>
+    <annotation-version>9.0.68</annotation-version>
     <guava-version>31.1-jre</guava-version>
-    <jackson-databind-version>2.13.4</jackson-databind-version>
-    <gson-version>2.9.1</gson-version>
+    <jackson-databind-version>2.13.4.2</jackson-databind-version>
+    <gson-version>2.10</gson-version>
     <thrift-version>0.16.0</thrift-version>
     <eclipse-collections-version>11.1.0</eclipse-collections-version>
     <log4j2-version>2.19.0</log4j2-version>
@@ -75,7 +75,7 @@
          since we have some custom optimized extensions to this -->
     <prometheus-version>0.9.0</prometheus-version>
     <bouncycastle-version>1.70</bouncycastle-version>
-    <junit-version>5.9.0</junit-version>
+    <junit-version>5.9.1</junit-version>
 
     <dockerhome>${project.build.directory}/dockerhome</dockerhome>
     <skipTests>false</skipTests>


### PR DESCRIPTION
grpc `1.50.2`, etcd-java `0.0.22`, protobuf `3.21.9`, jackson-databind `2.13.4.2`, gson `2.10`, junit `5.9.1`

Addresses jackson-databind CVE

Signed-off-by: Nick Hill <nickhill@us.ibm.com>