### PR TITLE
fix: Fix cache accounting in loading failures case

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/ModelCacheUnloadBufManager.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelCacheUnloadBufManager.java
@@ -95,6 +95,15 @@ final class ModelCacheUnloadBufManager {
         return UNLOAD_BUFF.getWeight();
     }
 
+    // For instrumentation/diagnostics only
+    int getTotalUnloadingWeight() {
+        return totalUnloadingWeight;
+    }
+    // For instrumentation/diagnostics only
+    long getTotalModelCacheOccupancy() {
+        return totalModelCacheOccupancy;
+    }
+
     void removeUnloadBufferEntry(Map<String, ?> entries) { //TODO TBD maybe static
         entries.remove(UNLOAD_BUFFER_CACHE_KEY);
     }


### PR DESCRIPTION
#### Motivation

Some issues have been observed in production where the cache appears to get into a broken state, including a cascading eviction of all models.

#### Modifications

- Fix cache accounting in loading failure + unload case
- Eagerly remove expired failure records from cache
- Correct misworded log message
- Log some internal cache values along with published instance records, to facilitate further diagnoses
- Increase load failure expiry times

#### Result

Hopefully fixed cache accounting issue