### PR TITLE
Push multi-arch docker image

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
     tags:
       - v*
+  pull_request:
 
 jobs:
   test:
@@ -23,26 +24,57 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
     env:
-      IMAGE_NAME: kserve/modelmesh
+      IMAGE_NAME: modelmesh
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Build and push runtime image
-      run: |
-        GIT_COMMIT=$(git rev-parse HEAD)
-        BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
+      - uses: actions/checkout@v2
 
-        # Strip git ref prefix from version
-        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
 
-        # Use Docker `latest` tag convention
-        [ "$VERSION" == "main" ] && VERSION=latest
-        echo $VERSION
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-        docker build -t ${{ env.IMAGE_NAME }}:$VERSION \
-          --build-arg imageVersion=$VERSION \
-          --build-arg buildId=${BUILD_ID} \
-          --build-arg commitSha=${GIT_COMMIT} .
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-        docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_ACCESS_TOKEN }}
-        docker push ${{ env.IMAGE_NAME }}:$VERSION
+      - name: export version variable
+        run: |
+          GIT_COMMIT=$(git rev-parse HEAD)
+          BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
+          
+          IMAGE_ID=kserve/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+
+          echo "GIT_COMMIT=$GIT_COMMIT" >> $GITHUB_ENV
+          echo "BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          push: true
+          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
+          build-args: |
+            imageVersion=${{ env.VERSION }}
+            buildId=${{ env.BUILD_ID }}
+            commitSha=${{ env.GIT_COMMIT }}


### PR DESCRIPTION
#### Motivation

Feature parity with kserve and knative ref https://github.com/kserve/kserve/pull/2550#discussion_r1055222609

Fixes https://github.com/kserve/kserve/issues/2612

#### Modifications

- Now runs `test` job on PR
- Now pushes multi-arch docker images on `push`

#### Result

Can run on e.g. AWS graviton family instances (arm64)