### PR TITLE
fix: `fq_names` parameter check

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/Metrics.java
+++ b/src/main/java/com/ibm/watson/modelmesh/Metrics.java
@@ -170,7 +170,7 @@ interface Metrics extends AutoCloseable {
                     }
                     break;
                 case "fq_names":
-                    shortNames = !"false".equalsIgnoreCase(ent.getValue());
+                    shortNames = !"true".equalsIgnoreCase(ent.getValue());
                     break;
                 case "scheme":
                     if ("http".equals(ent.getValue())) {
@@ -395,7 +395,7 @@ interface Metrics extends AutoCloseable {
                     legacy = "true".equalsIgnoreCase(ent.getValue());
                     break;
                 case "fq_names":
-                    shortNames = !"false".equalsIgnoreCase(ent.getValue());
+                    shortNames = !"true".equalsIgnoreCase(ent.getValue());
                     break;
                 default:
                     throw new Exception("Unrecognized metrics config parameter: " + ent.getKey());


### PR DESCRIPTION
#### Motivation

Follow up to PR #75, use short names (by default) unless `fq_names` is set to `true`

#### Modifications

Correct the boolean expression that sets `shortNames` based on the negated `fq_names` parameter value.

#### Result

Brief example to illustrate the behavior after this code change:

```Java
String[] fq_names_values = {"true", "True", "TRUE", "false", "False", "FALSE", "", "off", "on", "N/A"};

for (String fq_names_value: fq_names_values) {
    boolean shortNames = !"true".equalsIgnoreCase(fq_names_value);
    System.out.println("fq_names='%s' => shortNames=%s".formatted(fq_names_value, shortNames));
}
```

```
fq_names='true' => shortNames=false
fq_names='True' => shortNames=false
fq_names='TRUE' => shortNames=false
fq_names='false' => shortNames=true
fq_names='False' => shortNames=true
fq_names='FALSE' => shortNames=true
fq_names='' => shortNames=true
fq_names='off' => shortNames=true
fq_names='on' => shortNames=true
fq_names='N/A' => shortNames=true
```

/cc @njhill 
