### PR TITLE
Revert "Push multi-arch docker image (#76)"

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
     tags:
       - v*
-  pull_request:
 
 jobs:
   test:
@@ -24,57 +23,26 @@ jobs:
   build:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-
     env:
-      IMAGE_NAME: modelmesh
-
+      IMAGE_NAME: kserve/modelmesh
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+    - name: Build and push runtime image
+      run: |
+        GIT_COMMIT=$(git rev-parse HEAD)
+        BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
 
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        # Use Docker `latest` tag convention
+        [ "$VERSION" == "main" ] && VERSION=latest
+        echo $VERSION
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+        docker build -t ${{ env.IMAGE_NAME }}:$VERSION \
+          --build-arg imageVersion=$VERSION \
+          --build-arg buildId=${BUILD_ID} \
+          --build-arg commitSha=${GIT_COMMIT} .
 
-      - name: export version variable
-        run: |
-          GIT_COMMIT=$(git rev-parse HEAD)
-          BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
-          
-          IMAGE_ID=kserve/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name
-          # [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
-
-          echo "GIT_COMMIT=$GIT_COMMIT" >> $GITHUB_ENV
-          echo "BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
-
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
-          push: true
-          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
-          build-args: |
-            imageVersion=${{ env.VERSION }}
-            buildId=${{ env.BUILD_ID }}
-            commitSha=${{ env.GIT_COMMIT }}
+        docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_ACCESS_TOKEN }}
+        docker push ${{ env.IMAGE_NAME }}:$VERSION


### PR DESCRIPTION
This reverts commit d9892e3df7605e378b3076979ae75f9fc0040dd8.

These changes actually broke our main image build. Unfortunately the actions that run on the PR don't actually build the image. @ckadner is addressing that and then we can reopen this if needed post 0.10 release.

@ddelange it probably only makes sense anyhow if we do this for all the modelmesh images i.e. also including `modelmesh-serving` and `modelmesh-runtime-adapter`