### PR TITLE
feat: Allow custom prometheus info metric

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,13 @@
           </argLine>
           <!-- required to workaround issue with openjdk 8u181-b13-2 -->
           <useSystemClassLoader>false</useSystemClassLoader>
+          <environmentVariables>
+            <MM_INFO_METRICS>assistant_deployment_info:relabel;deployment=DEPLOYMENT_NAME,slot=SLOT_NAME,component=COMPONENT_NAME,group=GROUP_NAME</MM_INFO_METRICS>
+            <DEPLOYMENT_NAME>ga-tf-mm</DEPLOYMENT_NAME>
+            <SLOT_NAME>ga</SLOT_NAME>
+            <COMPONENT_NAME>tf-mm</COMPONENT_NAME>
+            <GROUP_NAME>clu</GROUP_NAME>
+          </environmentVariables>
         </configuration>
       </plugin>
 

--- a/src/main/java/com/ibm/watson/modelmesh/Metrics.java
+++ b/src/main/java/com/ibm/watson/modelmesh/Metrics.java
@@ -36,6 +36,7 @@ import io.prometheus.client.CollectorRegistry;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.lang.reflect.Array;
 import java.net.SocketAddress;
 import java.nio.channels.DatagramChannel;
 import java.util.*;
@@ -154,7 +155,7 @@ interface Metrics extends AutoCloseable {
         private final boolean shortNames;
         private final EnumMap<Metric, Collector> metricsMap = new EnumMap<>(Metric.class);
 
-        public PrometheusMetrics(Map<String, String> params, Map<String, String> infoMetricParams) throws Exception {
+        public PrometheusMetrics(Map<String, String> params, LinkedHashMap<String, String> infoMetricParams) throws Exception {
             int port = 2112;
             boolean shortNames = true;
             boolean https = true;
@@ -229,19 +230,10 @@ interface Metrics extends AutoCloseable {
                 }
             }
 
-            if (!infoMetricParams.isEmpty()){
+            if (infoMetricParams != null && !infoMetricParams.isEmpty()){
                 if (infoMetricParams.size() > INFO_METRICS_MAX) {
                     throw new Exception("Too many info metrics provided in env var " + MMESH_CUSTOM_ENV_VAR + ": \""
                             + infoMetricParams+ "\". The max is " + INFO_METRICS_MAX);
-                }
-
-                // Remove unset (unresolved) labels
-                for(String key : infoMetricParams.keySet()) {
-                    if(infoMetricParams.get(key).contains("$(")){
-                        infoMetricParams.remove(key);
-                        logger.info(("Info metric for label '" + key + "' is missing in env var: "
-                                + MMESH_CUSTOM_ENV_VAR));
-                    }
                 }
 
                 String metric_name = infoMetricParams.remove("metric_name");

--- a/src/main/java/com/ibm/watson/modelmesh/Metrics.java
+++ b/src/main/java/com/ibm/watson/modelmesh/Metrics.java
@@ -232,17 +232,13 @@ interface Metrics extends AutoCloseable {
 
             // Custom info metrics
             if (!customParams.isEmpty()){
-                @SuppressWarnings("rawtypes")
-                SimpleCollector.Builder builder;
-                builder = Gauge.build();
-                Collector collector = (
-                    builder
-                    .name(params.get("metric_name"))
-                    .help("Custom Info Metrics")
-                    .labelNames(params.get("deployment"), params.get("slot"), params.get("component"), params.get("group"))
-                    .create()
-                );
-                registry.register(collector);
+                Gauge customMetrics = Gauge.build()
+                        .name(customParams.get("metric_name"))
+                        .help("Info Metrics")
+                        .labelNames("deployment", "slot", "component", "group")
+                        .create();
+                customMetrics.labels(customParams.get("deployment"), customParams.get("slot"), customParams.get("component"), customParams.get("group"));
+                registry.register(customMetrics);
             }
 
             this.metricServer = new NettyServer(registry, port, https);

--- a/src/main/java/com/ibm/watson/modelmesh/Metrics.java
+++ b/src/main/java/com/ibm/watson/modelmesh/Metrics.java
@@ -232,7 +232,7 @@ interface Metrics extends AutoCloseable {
             if (!infoMetricParams.isEmpty()){
                 if (infoMetricParams.size() > INFO_METRICS_MAX) {
                     throw new Exception("Too many info metrics provided in env var " + MMESH_CUSTOM_ENV_VAR + ": \""
-                            + infoMetricParams+ "\"");
+                            + infoMetricParams+ "\". The max is " + INFO_METRICS_MAX);
                 }
 
                 // Remove unset (unresolved) labels
@@ -244,10 +244,11 @@ interface Metrics extends AutoCloseable {
                     }
                 }
 
+                String metric_name = infoMetricParams.remove("metric_name");
                 String[] labelNames = infoMetricParams.keySet().toArray(new String[0]);
                 String[] labelValues = infoMetricParams.values().toArray(new String[0]);
                 Gauge infoMetricsGauge = Gauge.build()
-                        .name(infoMetricParams.remove("metric_name"))
+                        .name(metric_name)
                         .help("Info Metrics")
                         .labelNames(labelNames)
                         .create();

--- a/src/main/java/com/ibm/watson/modelmesh/Metrics.java
+++ b/src/main/java/com/ibm/watson/modelmesh/Metrics.java
@@ -44,6 +44,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static com.ibm.watson.modelmesh.Metric.*;
 import static com.ibm.watson.modelmesh.ModelMesh.M;
@@ -155,7 +156,7 @@ interface Metrics extends AutoCloseable {
         private final boolean shortNames;
         private final EnumMap<Metric, Collector> metricsMap = new EnumMap<>(Metric.class);
 
-        public PrometheusMetrics(Map<String, String> params, LinkedHashMap<String, String> infoMetricParams) throws Exception {
+        public PrometheusMetrics(Map<String, String> params, Map<String, String> infoMetricParams) throws Exception {
             int port = 2112;
             boolean shortNames = true;
             boolean https = true;
@@ -237,8 +238,8 @@ interface Metrics extends AutoCloseable {
                 }
 
                 String metric_name = infoMetricParams.remove("metric_name");
-                String[] labelNames = infoMetricParams.keySet().toArray(new String[0]);
-                String[] labelValues = infoMetricParams.values().toArray(new String[0]);
+                String[] labelNames = infoMetricParams.keySet().toArray(String[]::new);
+                String[] labelValues = Stream.of(labelNames).map(infoMetricParams::get).toArray(String[]::new);
                 Gauge infoMetricsGauge = Gauge.build()
                         .name(metric_name)
                         .help("Info Metrics")

--- a/src/main/java/com/ibm/watson/modelmesh/Metrics.java
+++ b/src/main/java/com/ibm/watson/modelmesh/Metrics.java
@@ -155,7 +155,7 @@ interface Metrics extends AutoCloseable {
         private final boolean shortNames;
         private final EnumMap<Metric, Collector> metricsMap = new EnumMap<>(Metric.class);
 
-        public PrometheusMetrics(Map<String, String> params) throws Exception {
+        public PrometheusMetrics(Map<String, String> params, Map<String, String> customParams) throws Exception {
             int port = 2112;
             boolean shortNames = true;
             boolean https = true;
@@ -228,6 +228,21 @@ interface Metrics extends AutoCloseable {
                 if (!m.global) {
                     registry.register(collector);
                 }
+            }
+
+            // Custom info metrics
+            if (!customParams.isEmpty()){
+                @SuppressWarnings("rawtypes")
+                SimpleCollector.Builder builder;
+                builder = Gauge.build();
+                Collector collector = (
+                    builder
+                    .name(params.get("metric_name"))
+                    .help("Custom Info Metrics")
+                    .labelNames(params.get("deployment"), params.get("slot"), params.get("component"), params.get("group"))
+                    .create()
+                );
+                registry.register(collector);
             }
 
             this.metricServer = new NettyServer(registry, port, https);

--- a/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
@@ -919,7 +919,7 @@ public abstract class ModelMesh extends ThriftService
             }
         }
         String infoMetricConfig = getStringParameter(MMESH_CUSTOM_ENV_VAR, null);
-        LinkedHashMap<String, String> infoMetricParams; // To maintain the order when setting values in Gauge builder
+        Map<String, String> infoMetricParams;
         if (infoMetricConfig == null) {
             logger.info("{} returned null", MMESH_CUSTOM_ENV_VAR);
             infoMetricParams = null;
@@ -932,12 +932,12 @@ public abstract class ModelMesh extends ThriftService
             }
             String infoMetricName = infoMetricMatcher.group(1);
             String infoMetricParamString = infoMetricMatcher.group(2);
-            infoMetricParams = new LinkedHashMap<>();
+            infoMetricParams = new HashMap<>();
             infoMetricParams.put("metric_name", infoMetricName);
             for (String infoMetricParam : infoMetricParamString.substring(0).split(",")) {
                 String[] kv = infoMetricParam.split("=");
                 String value = System.getenv(kv[1]);
-                if(value == null){
+                if (value == null) {
                     throw new Exception("Env var " + kv[1] + " is unresolved in " + MMESH_CUSTOM_ENV_VAR + ": \""
                             + infoMetricConfig + "\"");
                 }

--- a/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
@@ -918,26 +918,25 @@ public abstract class ModelMesh extends ThriftService
                 params.put(kv[0], kv[1]);
             }
         }
-        String customMetricConfig = getStringParameter(MMESH_CUSTOM_ENV_VAR, null);
-        Map<String, String> customParams;
-        if (customMetricConfig == null) {
+        String infoMetricConfig = getStringParameter(MMESH_CUSTOM_ENV_VAR, null);
+        Map<String, String> infoMetricParams;
+        if (infoMetricConfig == null) {
             logger.info("{} returned null", MMESH_CUSTOM_ENV_VAR);
-            customParams = Collections.emptyMap();
+            infoMetricParams = Collections.emptyMap();
         } else {
-            logger.info("{} set to \"{}\"", MMESH_CUSTOM_ENV_VAR, customMetricConfig);
-            Matcher customMetricMatcher = CUSTOM_METRIC_CONFIG_PATT.matcher(customMetricConfig);
-            if (!customMetricMatcher.matches()) {
+            logger.info("{} set to \"{}\"", MMESH_CUSTOM_ENV_VAR, infoMetricConfig);
+            Matcher infoMetricMatcher = CUSTOM_METRIC_CONFIG_PATT.matcher(infoMetricConfig);
+            if (!infoMetricMatcher.matches()) {
                 throw new Exception("Invalid metrics configuration provided in env var " + MMESH_CUSTOM_ENV_VAR + ": \""
-                                    + customMetricConfig + "\"");
+                                    + infoMetricConfig + "\"");
             }
-            String name = customMetricMatcher.group(1);
-            String customParamString = customMetricMatcher.group(2);
-
-            customParams = new HashMap<>();
-            customParams.put("metric_name", name);
-            for (String customParm : customParamString.substring(0).split(",")) {
-                String[] kv = customParm.split("=");
-                customParams.put(kv[0], kv[1]);
+            String infoMetricName = infoMetricMatcher.group(1);
+            String infoMetricParamString = infoMetricMatcher.group(2);
+            infoMetricParams = new LinkedHashMap<>(); // To maintain the order when setting values in Gauge builder
+            infoMetricParams.put("metric_name", infoMetricName);
+            for (String infoMetricParam : infoMetricParamString.substring(0).split(",")) {
+                String[] kv = infoMetricParam.split("=");
+                infoMetricParams.put(kv[0], kv[1]);
             }
         }
         try {
@@ -945,7 +944,7 @@ public abstract class ModelMesh extends ThriftService
             case "statsd":
                 return new Metrics.StatsDMetrics(params);
             case "prometheus":
-                return new Metrics.PrometheusMetrics(params, customParams);
+                return new Metrics.PrometheusMetrics(params, infoMetricParams);
             case "disabled":
                 logger.info("Metrics publishing is disabled (env var {}={})", MMESH_METRICS_ENV_VAR, metricsConfig);
                 return Metrics.NO_OP_METRICS;

--- a/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
@@ -932,9 +932,10 @@ public abstract class ModelMesh extends ThriftService
             }
             String name = customMetricMatcher.group(1);
             String customParamString = customMetricMatcher.group(2);
+
             customParams = new HashMap<>();
             customParams.put("metric_name", name);
-            for (String customParm : customParamString.substring(1).split(",")) {
+            for (String customParm : customParamString.substring(0).split(",")) {
                 String[] kv = customParm.split("=");
                 customParams.put(kv[0], kv[1]);
             }

--- a/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java
@@ -46,6 +46,7 @@ public final class ModelMeshEnvVars {
     public static final String LOAD_FAILURE_EXPIRY_ENV_VAR = "MM_LOAD_FAILURE_EXPIRY_TIME_MS";
 
     public static final String MMESH_METRICS_ENV_VAR = "MM_METRICS";
+    public static final String MMESH_CUSTOM_ENV_VAR = "MM_INFO_METRICS";
 
     public static final String LOG_EACH_INVOKE_ENV_VAR = "MM_LOG_EACH_INVOKE";
     public static final String SEND_DEST_ID_ENV_VAR = "MM_SEND_DEST_ID";

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
@@ -68,6 +68,7 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
 
     static final String SCHEME = "https"; // or http
 
+    static final String METRIC_NAME = "assistant_deployment_info:relabel";
     static final String DEPLOYMENT_NAME = "ga-tf-mm";
     static final String SLOT_NAME = "ga";
     static final String COMPONENT_NAME = "tf-mm";
@@ -77,7 +78,7 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
     protected Map<String, String> extraEnvVars() {
         return  ImmutableMap.of(
                 "MM_METRICS", "prometheus:port=" + METRICS_PORT + ";scheme=" + SCHEME,
-                "MM_INFO_METRICS", "assistant_deployment_info:relabel;deployment=" + DEPLOYMENT_NAME
+                "MM_INFO_METRICS", METRIC_NAME + ";deployment=" + DEPLOYMENT_NAME
                         + ",slot=" + SLOT_NAME + ",component=" + COMPONENT_NAME + ",group=" + GROUP_NAME);
     }
 
@@ -174,7 +175,6 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
                 .filter(Matcher::matches)
                 .collect(Collectors.toMap(m -> m.group(1), m -> Double.parseDouble(m.group(2))));
 
-
         System.out.println(metrics.size() + " metrics scraped");
 
         // Spot check some expected metrics and values
@@ -208,7 +208,7 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
         assertTrue(metrics.containsKey("jvm_memory_bytes_committed{area=\"heap\",}"));
 
         // Info metrics
-        assertEquals(0.0, metrics.get("assistant_deployment_info:relabel{deployment=\""
-                + DEPLOYMENT_NAME + "\",slot=\"" + SLOT_NAME + "\",component=\"" + COMPONENT_NAME + "\",group=\"" + GROUP_NAME + "\",}"));
+        assertEquals(1.0, metrics.get("assistant_deployment_info:relabel{deployment=\"" + DEPLOYMENT_NAME
+                + "\",slot=\"" + SLOT_NAME + "\",component=\"" + COMPONENT_NAME + "\",group=\"" + GROUP_NAME + "\",}"));
     }
 }

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
@@ -205,8 +205,8 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
         assertTrue(metrics.containsKey("jvm_memory_bytes_committed{area=\"heap\",}"));
 
         // Info metrics
-        assertEquals(1.0, metrics.get("assistant_deployment_info:relabel{deployment=\"" + DEPLOYMENT_NAME
-                + "\",slot=\"" + SLOT_NAME + "\",component=\"" + COMPONENT_NAME + "\",group=\"" + GROUP_NAME + "\",}"));
+        assertEquals(1.0, metrics.get(METRIC_NAME + "{component=\"" + COMPONENT_NAME
+                + "\",slot=\"" + SLOT_NAME + "\",deployment=\"" + DEPLOYMENT_NAME + "\",group=\"" + GROUP_NAME + "\",}"));
     }
 
 }

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
@@ -68,11 +68,17 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
 
     static final String SCHEME = "https"; // or http
 
+    static final String DEPLOYMENT_NAME = "ga-tf-mm";
+    static final String SLOT_NAME = "ga";
+    static final String COMPONENT_NAME = "tf-mm";
+    static final String GROUP_NAME = "clu";
+
     @Override
     protected Map<String, String> extraEnvVars() {
         return  ImmutableMap.of(
                 "MM_METRICS", "prometheus:port=" + METRICS_PORT + ";scheme=" + SCHEME,
-                "MM_INFO_METRICS", "assistant_deployment_info:relabel;deployment=DEPLOYMENT_NAME,slot=SLOT_NAME,component=COMPONENT_NAME,group=GROUP_NAME");
+                "MM_INFO_METRICS", "assistant_deployment_info:relabel;deployment=" + DEPLOYMENT_NAME
+                        + ",slot=" + SLOT_NAME + ",component=" + COMPONENT_NAME + ",group=" + GROUP_NAME);
     }
 
     @Test
@@ -202,7 +208,7 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
         assertTrue(metrics.containsKey("jvm_memory_bytes_committed{area=\"heap\",}"));
 
         // Info metrics
-        assertTrue(metrics.containsKey("assistant_deployment_info:relabel{deployment=\"DEPLOYMENT_NAME\",slot=\"SLOT_NAME\",component=\"COMPONENT_NAME\",group=\"GROUP_NAME\",}"));
-        assertEquals(0.0, metrics.get("assistant_deployment_info:relabel{deployment=\"DEPLOYMENT_NAME\",slot=\"SLOT_NAME\",component=\"COMPONENT_NAME\",group=\"GROUP_NAME\",}"));
+        assertEquals(0.0, metrics.get("assistant_deployment_info:relabel{deployment=\""
+                + DEPLOYMENT_NAME + "\",slot=\"" + SLOT_NAME + "\",component=\"" + COMPONENT_NAME + "\",group=\"" + GROUP_NAME + "\",}"));
     }
 }

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
@@ -70,7 +70,9 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
 
     @Override
     protected Map<String, String> extraEnvVars() {
-        return  ImmutableMap.of("MM_METRICS", "prometheus:port=" + METRICS_PORT + ";scheme=" + SCHEME);
+        return  ImmutableMap.of(
+                "MM_METRICS", "prometheus:port=" + METRICS_PORT + ";scheme=" + SCHEME,
+                "MM_INFO_METRICS", "assistant_deployment_info:relabel;deployment=DEPLOYMENT_NAME,slot=SLOT_NAME,component=COMPONENT_NAME,group=GROUP_NAME");
     }
 
     @Test
@@ -84,7 +86,7 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
 
             // verify not found status
             ModelStatusInfo status = manageModels.getModelStatus(GetStatusRequest.newBuilder()
-                    .setModelId("i don't exist").build());
+                    .setModelId("I don't exist").build());
 
             assertEquals(ModelStatus.NOT_FOUND, status.getStatus());
             assertEquals(0, status.getErrorsCount());
@@ -198,5 +200,9 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
         assertEquals(0.0, metrics.get("jvm_buffer_pool_used_buffers{pool=\"mapped\",}")); // mmapped memory not used
         assertTrue(metrics.containsKey("jvm_gc_collection_seconds_sum{gc=\"G1 Young Generation\",}"));
         assertTrue(metrics.containsKey("jvm_memory_bytes_committed{area=\"heap\",}"));
+
+        // Info metrics
+        assertTrue(metrics.containsKey("assistant_deployment_info:relabel{deployment=\"DEPLOYMENT_NAME\",slot=\"SLOT_NAME\",component=\"COMPONENT_NAME\",group=\"GROUP_NAME\",}"));
+        assertEquals(0.0, metrics.get("assistant_deployment_info:relabel{deployment=\"DEPLOYMENT_NAME\",slot=\"SLOT_NAME\",component=\"COMPONENT_NAME\",group=\"GROUP_NAME\",}"));
     }
 }

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
@@ -68,18 +68,9 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
 
     static final String SCHEME = "https"; // or http
 
-    static final String METRIC_NAME = "assistant_deployment_info:relabel";
-    static final String DEPLOYMENT_NAME = "ga-tf-mm";
-    static final String SLOT_NAME = "ga";
-    static final String COMPONENT_NAME = "tf-mm";
-    static final String GROUP_NAME = "clu";
-
     @Override
     protected Map<String, String> extraEnvVars() {
-        return  ImmutableMap.of(
-                "MM_METRICS", "prometheus:port=" + METRICS_PORT + ";scheme=" + SCHEME,
-                "MM_INFO_METRICS", METRIC_NAME + ";deployment=" + DEPLOYMENT_NAME
-                        + ",slot=" + SLOT_NAME + ",component=" + COMPONENT_NAME + ",group=" + GROUP_NAME);
+        return  ImmutableMap.of("MM_METRICS", "prometheus:port=" + METRICS_PORT + ";scheme=" + SCHEME);
     }
 
     @Test
@@ -206,9 +197,5 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
         assertEquals(0.0, metrics.get("jvm_buffer_pool_used_buffers{pool=\"mapped\",}")); // mmapped memory not used
         assertTrue(metrics.containsKey("jvm_gc_collection_seconds_sum{gc=\"G1 Young Generation\",}"));
         assertTrue(metrics.containsKey("jvm_memory_bytes_committed{area=\"heap\",}"));
-
-        // Info metrics
-        assertEquals(1.0, metrics.get("assistant_deployment_info:relabel{deployment=\"" + DEPLOYMENT_NAME
-                + "\",slot=\"" + SLOT_NAME + "\",component=\"" + COMPONENT_NAME + "\",group=\"" + GROUP_NAME + "\",}"));
     }
 }

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshMetricsTest.java
@@ -68,6 +68,12 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
 
     static final String SCHEME = "https"; // or http
 
+    static final String METRIC_NAME = "assistant_deployment_info:relabel";
+    static final String DEPLOYMENT_NAME = "ga-tf-mm";
+    static final String SLOT_NAME = "ga";
+    static final String COMPONENT_NAME = "tf-mm";
+    static final String GROUP_NAME = "clu";
+
     @Override
     protected Map<String, String> extraEnvVars() {
         return  ImmutableMap.of("MM_METRICS", "prometheus:port=" + METRICS_PORT + ";scheme=" + SCHEME);
@@ -197,5 +203,10 @@ public class ModelMeshMetricsTest extends AbstractModelMeshClusterTest {
         assertEquals(0.0, metrics.get("jvm_buffer_pool_used_buffers{pool=\"mapped\",}")); // mmapped memory not used
         assertTrue(metrics.containsKey("jvm_gc_collection_seconds_sum{gc=\"G1 Young Generation\",}"));
         assertTrue(metrics.containsKey("jvm_memory_bytes_committed{area=\"heap\",}"));
+
+        // Info metrics
+        assertEquals(1.0, metrics.get("assistant_deployment_info:relabel{deployment=\"" + DEPLOYMENT_NAME
+                + "\",slot=\"" + SLOT_NAME + "\",component=\"" + COMPONENT_NAME + "\",group=\"" + GROUP_NAME + "\",}"));
     }
+
 }


### PR DESCRIPTION
#### Motivation
Allow the generation of an "info" metric by way of environment variables captured as `Gauge` metric set up during container startup

#### Modifications
- Added environment variable `MMESH_CUSTOM_ENV_VAR` in `ModelMeshEnvVars`
- Added map `infoMetricParams` and logic to parse and pass the info to prometheus in `ModelMesh`
- Added a `Gauge` using the parsed label names and values in `Metrics`
- Added sample variables to `pom.xml` for testing and related test in `ModelMeshMetricsTest`

#### Result
- Support to pass information by via environment variables parsed as `<metricname>[;label1=envVarWithValueforLabel1,label2=envVarWithValueforLabel2,...,labelN=envVarWithValueforLabelN,]` if provided.

