### PR TITLE
feat: Add per model metrics

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
@@ -1896,7 +1896,7 @@ public abstract class ModelMesh extends ThriftService
                     // "unload" event if explicit unloading isn't enabled.
                     // Otherwise, this gets recorded in a callback set in the
                     // CacheEntry.unload(int) method
-                    metrics.logTimingMetricDuration(Metric.UNLOAD_MODEL_TIME, 0L, false);
+                    metrics.logTimingMetricDuration(Metric.UNLOAD_MODEL_TIME, 0L, false, modelId, "");
                     metrics.logCounterMetric(Metric.UNLOAD_MODEL);
                 }
             }
@@ -1967,7 +1967,7 @@ public abstract class ModelMesh extends ThriftService
                         //TODO probably only log if took longer than a certain time
                         long tookMillis = msSince(beforeNanos);
                         logger.info("Unload of " + modelId + " completed in " + tookMillis + "ms");
-                        metrics.logTimingMetricDuration(Metric.UNLOAD_MODEL_TIME, tookMillis, false);
+                        metrics.logTimingMetricDuration(Metric.UNLOAD_MODEL_TIME, tookMillis, false, modelId, "");
                         metrics.logCounterMetric(Metric.UNLOAD_MODEL);
                     }
                     // else considered trivially succeeded because the corresponding
@@ -2088,7 +2088,7 @@ public abstract class ModelMesh extends ThriftService
                     long queueStartTimeNanos = getAndResetLoadingQueueStartTimeNanos();
                     if (queueStartTimeNanos > 0) {
                         long queueDelayMillis = (nanoTime() - queueStartTimeNanos) / M;
-                        metrics.logSizeEventMetric(Metric.LOAD_MODEL_QUEUE_DELAY, queueDelayMillis);
+                        metrics.logSizeEventMetric(Metric.LOAD_MODEL_QUEUE_DELAY, queueDelayMillis, modelId, "");
                         // Only log if the priority value is "in the future" which indicates
                         // that there is or were runtime requests waiting for this load.
                         // Otherwise we don't care about arbitrary delays here
@@ -2158,7 +2158,7 @@ public abstract class ModelMesh extends ThriftService
                         loadingTimeStats(modelType).recordTime(tookMillis);
                         logger.info("Load of model " + modelId + " type=" + modelType + " completed in " + tookMillis
                                     + "ms");
-                        metrics.logTimingMetricDuration(Metric.LOAD_MODEL_TIME, tookMillis, false);
+                        metrics.logTimingMetricDuration(Metric.LOAD_MODEL_TIME, tookMillis, false, modelId, "");
                         metrics.logCounterMetric(Metric.LOAD_MODEL);
                     } catch (Throwable t) {
                         loadFuture = null;
@@ -2318,7 +2318,7 @@ public abstract class ModelMesh extends ThriftService
                     if (size > 0) {
                         long sizeBytes = size * UNIT_SIZE;
                         logger.info("Model " + modelId + " size = " + size + " units" + ", ~" + mb(sizeBytes));
-                        metrics.logSizeEventMetric(Metric.LOADED_MODEL_SIZE, sizeBytes);
+                        metrics.logSizeEventMetric(Metric.LOADED_MODEL_SIZE, sizeBytes, modelId, "");
                     } else {
                         try {
                             long before = nanoTime();
@@ -2327,9 +2327,9 @@ public abstract class ModelMesh extends ThriftService
                                 long took = msSince(before), sizeBytes = size * UNIT_SIZE;
                                 logger.info("Model " + modelId + " size = " + size + " units" + ", ~" + mb(sizeBytes)
                                             + " sizing took " + took + "ms");
-                                metrics.logTimingMetricDuration(Metric.MODEL_SIZING_TIME, took, false);
+                                metrics.logTimingMetricDuration(Metric.MODEL_SIZING_TIME, took, false, modelId, "");
                                 // this is actually a size (bytes), not a "time"
-                                metrics.logSizeEventMetric(Metric.LOADED_MODEL_SIZE, sizeBytes);
+                                metrics.logSizeEventMetric(Metric.LOADED_MODEL_SIZE, sizeBytes, modelId, "");
                             }
                         } catch (Exception e) {
                             if (!isInterruption(e) && state == SIZING) {
@@ -2652,7 +2652,7 @@ public abstract class ModelMesh extends ThriftService
                         //noinspection ThrowFromFinallyBlock
                         throw new ModelNotHereException(instanceId, modelId);
                     }
-                    metrics.logTimingMetricDuration(Metric.QUEUE_DELAY, tookMillis, false);
+                    metrics.logTimingMetricDuration(Metric.QUEUE_DELAY, tookMillis, false, modelId, "");
                 }
             }
         }
@@ -2831,7 +2831,7 @@ public abstract class ModelMesh extends ThriftService
                 logger.info("Evicted " + (failed ? "failed model record" : "model") + " " + key
                     + " from local cache, last used " + readableTime(millisSinceLastUsed) + " ago (" + lastUsed
                     + "ms), invoked " + ce.getTotalInvocationCount() + " times");
-                metrics.logTimingMetricDuration(Metric.AGE_AT_EVICTION, millisSinceLastUsed, false);
+                metrics.logTimingMetricDuration(Metric.AGE_AT_EVICTION, millisSinceLastUsed, false, ce.modelId, "");
                 metrics.logCounterMetric(Metric.EVICT_MODEL);
             }
 
@@ -3919,9 +3919,10 @@ public abstract class ModelMesh extends ThriftService
             throw t;
         } finally {
             if (methodStartNanos > 0L && metrics.isEnabled()) {
+                String[] extraLabels = new String[]{modelId};
                 // only logged here in non-grpc (legacy) mode
                 metrics.logRequestMetrics(true, getRequestMethodName(method, args),
-                        nanoTime() - methodStartNanos, metricStatusCode, -1, -1);
+                        nanoTime() - methodStartNanos, metricStatusCode, -1, -1, modelId, "");
             }
             curThread.setName(threadNameBefore);
         }
@@ -4380,7 +4381,7 @@ public abstract class ModelMesh extends ThriftService
                         long delayMillis = msSince(beforeNanos);
                         logger.info("Cache miss for model invocation, held up " + delayMillis + "ms");
                         metrics.logCounterMetric(Metric.CACHE_MISS);
-                        metrics.logTimingMetricDuration(Metric.CACHE_MISS_DELAY, delayMillis, false);
+                        metrics.logTimingMetricDuration(Metric.CACHE_MISS_DELAY, delayMillis, false, ce.modelId, "");
                     }
                 }
             } else {
@@ -4458,7 +4459,7 @@ public abstract class ModelMesh extends ThriftService
             ce.afterInvoke(weight, tookNanos);
             if (code != null && metrics.isEnabled()) {
                 metrics.logRequestMetrics(false, getRequestMethodName(method, args),
-                        tookNanos, code, -1, -1);
+                        tookNanos, code, -1, -1, ce.modelId, "");
             }
         }
     }

--- a/src/main/java/com/ibm/watson/modelmesh/ModelMeshApi.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMeshApi.java
@@ -85,6 +85,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import org.apache.thrift.TException;
+import org.checkerframework.checker.units.qual.A;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -751,8 +752,13 @@ public final class ModelMeshApi extends ModelMeshGrpc.ModelMeshImplBase
                     call.close(status, emptyMeta());
                     Metrics metrics = delegate.metrics;
                     if (metrics.isEnabled()) {
-                        metrics.logRequestMetrics(true, methodName, nanoTime() - startNanos,
-                                status.getCode(), reqSize, respSize);
+                        if (isVModel) {
+                            metrics.logRequestMetrics(true, methodName, nanoTime() - startNanos,
+                                    status.getCode(), reqSize, respSize, "", Iterables.toString(modelIds));
+                        } else {
+                            metrics.logRequestMetrics(true, methodName, nanoTime() - startNanos,
+                                    status.getCode(), reqSize, respSize, Iterables.toString(modelIds), "");
+                        }
                     }
                 }
             }

--- a/src/main/java/com/ibm/watson/prometheus/SimpleCollector.java
+++ b/src/main/java/com/ibm/watson/prometheus/SimpleCollector.java
@@ -161,7 +161,7 @@ public abstract class SimpleCollector<Child> extends Collector {
 
   private void validateCount(int count) {
     if (count != labelCount) {
-      throw new IllegalArgumentException("Incorrect number of labels.");
+      throw new IllegalArgumentException("Incorrect number of labels. Expected: " + labelCount + ", got: " + count);
     }
   }
 

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshPerModelMetricsTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshPerModelMetricsTest.java
@@ -1,0 +1,57 @@
+package com.ibm.watson.modelmesh;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ModelMeshPerModelMetricsTest extends ModelMeshMetricsTest {
+    @Override
+    protected Map<String, String> extraEnvVars() {
+        return ImmutableMap.of("MM_METRICS", "prometheus:port=" + METRICS_PORT + ";scheme=" + SCHEME +
+                ";per_model_metrics=true");
+    }
+    @Override
+    @Test
+    public void verifyMetrics() throws Exception {
+        // Insecure trust manager - skip TLS verification
+        prepareMetrics();
+
+        System.out.println(metrics.size() + " metrics scraped");
+
+        // Spot check some expected metrics and values
+
+        // External response time should all be < 2000ms (includes cache hit loading time)
+        assertEquals(40.0,
+                metrics.get("modelmesh_api_request_milliseconds_bucket{method=\"predict\",code=\"OK\",modelId=\"\"," +
+                        "vModelId=\"\",le=\"2000.0\",}"));
+        // External response time should all be < 200ms (includes cache hit loading time)
+        assertEquals(40.0,
+                metrics.get("modelmesh_invoke_model_milliseconds_bucket{method=\"predict\",code=\"OK\",modelId=\"\",vModelId=\"\",le=\"120000.0\",}"));
+        // Simulated model sizing time is < 200ms
+        assertEquals(1.0, metrics.get("modelmesh_model_sizing_milliseconds_bucket{modelId=\"myModel\",vModelId=\"\",le=\"60000.0\",}"));
+        // Simulated model sizing time is > 50ms
+        assertEquals(0.0, metrics.get("modelmesh_model_sizing_milliseconds_bucket{modelId=\"myModel\",vModelId=\"\",le=\"50.0\",}"));
+        // Simulated model size is between 64MiB and 256MiB
+        assertEquals(0.0, metrics.get("modelmesh_loaded_model_size_bytes_bucket{modelId=\"myModel\",vModelId=\"\",le=\"6.7108864E7\",}"));
+        assertEquals(1.0, metrics.get("modelmesh_loaded_model_size_bytes_bucket{modelId=\"myModel\",vModelId=\"\",le=\"2.68435456E8\",}"));
+        // One model is loaded
+        assertEquals(1.0, metrics.get("modelmesh_instance_models_total"));
+        // Histogram counts should reflect the two payload sizes (30 small, 10 large)
+        assertEquals(30.0, metrics.get("modelmesh_request_size_bytes_bucket{method=\"predict\",code=\"OK\",modelId=\"\",vModelId=\"\",le=\"128.0\",}"));
+        assertEquals(40.0, metrics.get("modelmesh_request_size_bytes_bucket{method=\"predict\",code=\"OK\",modelId=\"\",vModelId=\"\",le=\"2097152.0\",}"));
+        assertEquals(30.0, metrics.get("modelmesh_response_size_bytes_bucket{method=\"predict\",code=\"OK\",modelId=\"\",vModelId=\"\",le=\"128.0\",}"));
+        assertEquals(40.0, metrics.get("modelmesh_response_size_bytes_bucket{method=\"predict\",code=\"OK\",modelId=\"\",vModelId=\"\",le=\"2097152.0\",}"));
+
+        // Memory metrics
+        assertTrue(metrics.containsKey("netty_pool_mem_allocated_bytes{area=\"direct\",}"));
+        assertTrue(metrics.containsKey("jvm_memory_pool_bytes_used{pool=\"G1 Eden Space\",}"));
+        assertTrue(metrics.containsKey("jvm_buffer_pool_used_bytes{pool=\"direct\",}"));
+        assertEquals(0.0, metrics.get("jvm_buffer_pool_used_buffers{pool=\"mapped\",}")); // mmapped memory not used
+        assertTrue(metrics.containsKey("jvm_gc_collection_seconds_sum{gc=\"G1 Young Generation\",}"));
+        assertTrue(metrics.containsKey("jvm_memory_bytes_committed{area=\"heap\",}"));
+    }
+}


### PR DESCRIPTION
#### Motivation
Fixes #60 

#### Modifications
1. Added a new configuration parameter, i.e. `per_model_metrics`, when true metrics are labeled with modelid for each configured metric.

#### Result
