### PR TITLE
Fix multi-platform build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,15 @@
+**/*.class
+*.jar
+*.md
+.DS_Store
+.cache
+.dockerignore
 .env
+.git
+.github
+.gitignore
+.idea
+.vscode
+default.etcd
+target
+temp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Push
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
     - name: Set up Java 17
       uses: actions/setup-java@v3.1.1
       with:
         java-version: '17'
         distribution: 'temurin'
+
     - name: Install etcd
       run: sudo ./.github/install-etcd.sh
+
     - name: Build and Test with Maven
       run: mvn -B package --file pom.xml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,36 +1,46 @@
 name: Build
 
 on:
-  push:
-    branches: [ main ]
-    tags:
-      - v*
   pull_request:
+    branches:
+      - main
+      - "release-[0-9].[0-9]+"
+    paths-ignore:
+      - "**.md"
+  push:
+    branches:
+      - main
+      - "release-[0-9].[0-9]+"
+    tags:
+      - "v*"
+    paths-ignore:
+      - "**.md"
+
+env:
+  IMAGE_NAME: "kserve/modelmesh"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up Java 17
       uses: actions/setup-java@v3.1.1
       with:
         java-version: '17'
         distribution: 'temurin'
     - name: Install etcd
       run: sudo ./.github/install-etcd.sh
-    - name: Build with Maven
+    - name: Build and Test with Maven
       run: mvn -B package --file pom.xml
 
   build:
     needs: test
     runs-on: ubuntu-latest
-
-    env:
-      IMAGE_NAME: kserve/modelmesh
-
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
@@ -45,7 +55,7 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      - name: Export version variables
+      - name: Export docker build args
         run: |
           GIT_COMMIT=$(git rev-parse HEAD)
           BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
@@ -53,24 +63,30 @@ jobs:
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
+          # Generate PR tag from github.ref == "refs/pull/123/merge"
+          [ "$VERSION" == "merge" ] && VERSION=$(echo "${{ github.ref }}" | sed -e 's,refs/pull/\(.*\)/merge,pr-\1,')
+
           # Use Docker `latest` tag convention
           [ "$VERSION" == "main" ] && VERSION=latest
 
           echo "GIT_COMMIT=$GIT_COMMIT" >> $GITHUB_ENV
-          echo "BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "BUILD_ID=$BUILD_ID"     >> $GITHUB_ENV
+          echo "VERSION=$VERSION"       >> $GITHUB_ENV
 
-      - name: Build and push
-        uses: docker/build-push-action@v3
+          # print env vars for debugging
+          cat "$GITHUB_ENV"
+
+      - name: Build and push runtime image
+        uses: docker/build-push-action@v4
         with:
           # for linux/s390x, maven errors due to missing io.grpc:protoc-gen-grpc-java:exe:linux-s390_64:1.51.1
           platforms: linux/amd64,linux/arm64/v8,linux/ppc64le
-          pull: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          target: runtime
           push: ${{ github.event_name == 'push' }}
           tags: ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           build-args: |
             imageVersion=${{ env.VERSION }}
             buildId=${{ env.BUILD_ID }}
             commitSha=${{ env.GIT_COMMIT }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,11 @@
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as build_base
 
-# https://blog.thesparktree.com/docker-multi-arch-github-actions#architecture-specific-dockerfile-instructions
-ARG TARGETARCH=amd64
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+# don't provide "default" values (e.g. 'ARG TARGETARCH=amd64') for non-buildx environments,
+# see https://github.com/docker/buildx/issues/510
+ARG TARGETOS
+ARG TARGETARCH
 
 ARG ETCD_VERSION=v3.5.4
 
@@ -23,22 +26,29 @@ LABEL image="build_base"
 
 USER root
 
-RUN true \
-    && microdnf --nodocs install java-17-openjdk-devel nss \
+RUN --mount=type=cache,target=/root/.cache/microdnf:rw \
+    microdnf --setopt=cachedir=/root/.cache/microdnf --nodocs install \
+       java-17-openjdk-devel \
+       nss \
     && microdnf update --nodocs \
-    && microdnf clean all \
     && sed -i 's:security.provider.12=SunPKCS11:#security.provider.12=SunPKCS11:g' /usr/lib/jvm/java-17-openjdk-*/conf/security/java.security \
     && sed -i 's:#security.provider.1=SunPKCS11 ${java.home}/lib/security/nss.cfg:security.provider.12=SunPKCS11 ${java.home}/lib/security/nss.cfg:g' /usr/lib/jvm/java-17-openjdk-*/conf/security/java.security \
     && true
 
-RUN microdnf install wget tar gzip maven
+RUN --mount=type=cache,target=/root/.cache/microdnf:rw \
+    microdnf --setopt=cachedir=/root/.cache/microdnf --nodocs install \
+       wget \
+       tar \
+       gzip \
+       maven \
+    && true
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
 # Install etcd -- used for CI tests
-RUN wget -q https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-${TARGETARCH}.tar.gz && \
+RUN wget -q https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-${TARGETOS:-linux}-${TARGETARCH:-amd64}.tar.gz && \
     mkdir -p /usr/lib/etcd && \
-    tar xzf etcd-*-linux-${TARGETARCH}.tar.gz -C /usr/lib/etcd --strip-components=1 --no-same-owner && \
+    tar xzf etcd-*-${TARGETOS:-linux}-${TARGETARCH:-amd64}.tar.gz -C /usr/lib/etcd --strip-components=1 --no-same-owner && \
     rm -rf etcd*.gz
 
 ENV PATH="/usr/lib/etcd:$PATH"
@@ -57,30 +67,23 @@ COPY / /build
 
 ENV MAVEN_OPTS="-Dfile.encoding=UTF8"
 
-RUN mvn -B package -DskipTests=true --file pom.xml
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B package -DskipTests=true --file pom.xml
 
 ###############################################################################
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 
-ARG imageVersion
-ARG buildId
-ARG commitSha
-ARG USER=2000
+# TODO: FROM registry.access.redhat.com/ubi8/openjdk-17-runtime:1.15
 
-LABEL name="model-mesh" \
-      vendor="KServe" \
-      version="${imageVersion}" \
-      summary="Core model-mesh sidecar image" \
-      description="Model-mesh is a distributed LRU cache for serving runtime models" \
-      release="${commitSha}"
-LABEL maintainer=nickhill@us.ibm.com
+ARG USER=2000
 
 USER root
 
-RUN true \
-    && microdnf --nodocs install java-17-openjdk-headless nss \
+RUN --mount=type=cache,target=/root/.cache/microdnf:rw \
+    microdnf --setopt=cachedir=/root/.cache/microdnf --nodocs install \
+       java-17-openjdk-headless \
+       nss \
     && microdnf update --nodocs \
-    && microdnf clean all \
     && sed -i 's:security.provider.12=SunPKCS11:#security.provider.12=SunPKCS11:g' /usr/lib/jvm/java-17-openjdk-*/conf/security/java.security \
     && sed -i 's:#security.provider.1=SunPKCS11 ${java.home}/lib/security/nss.cfg:security.provider.12=SunPKCS11 ${java.home}/lib/security/nss.cfg:g' /usr/lib/jvm/java-17-openjdk-*/conf/security/java.security \
     && true
@@ -92,22 +95,40 @@ COPY --from=build /build/target/dockerhome/ /opt/kserve/mmesh/
 # Make this the current directory when starting the container
 WORKDIR /opt/kserve/mmesh
 
-RUN microdnf install shadow-utils hostname && \
+RUN --mount=type=cache,target=/root/.cache/microdnf:rw \
+    microdnf --setopt=cachedir=/root/.cache/microdnf --nodocs install \
+       shadow-utils \
+       hostname \
     # Create app user
-    useradd -c "Application User" -U -u ${USER} -m app && \
-    chown -R app:0 /home/app && \
+    && useradd -c "Application User" -U -u ${USER} -m app \
+    && chown -R app:0 /home/app \
     # Adjust permissions on /etc/passwd to be writable by group root.
     # The user app is replaced by the assigned UID on OpenShift.
-    chmod g+w /etc/passwd && \
+    && chmod g+w /etc/passwd \
     # In newer Docker there is a --chown option for the COPY command
-    ln -s /opt/kserve/mmesh /opt/kserve/tas && \
-    mkdir -p log && \
-    chown -R app:0 . && \
-    chmod -R 771 . && chmod 775 *.sh *.py && \
-    echo "${buildId}" > /opt/kserve/mmesh/build-version && \
-    \
+    && ln -s /opt/kserve/mmesh /opt/kserve/tas \
+    && mkdir -p log \
+    && chown -R app:0 . \
+    && chmod -R 771 . && chmod 775 *.sh *.py \
     # Disable java FIPS - see https://access.redhat.com/documentation/en-us/openjdk/17/html-single/configuring_openjdk_17_on_rhel_with_fips/index#config-fips-in-openjdk
-    sed -i 's/security.useSystemPropertiesFile=true/security.useSystemPropertiesFile=false/g' $JAVA_HOME/conf/security/java.security
+    && sed -i 's/security.useSystemPropertiesFile=true/security.useSystemPropertiesFile=false/g' $JAVA_HOME/conf/security/java.security \
+    && true
+
+# wait to create commit-specific LABEL until end of the build to not unnecessarily
+# invalidate the cached image layers
+ARG imageVersion
+ARG buildId
+ARG commitSha
+
+RUN echo "${buildId}" > /opt/kserve/mmesh/build-version
+
+LABEL name="model-mesh" \
+      vendor="KServe" \
+      version="${imageVersion}" \
+      summary="Core model-mesh sidecar image" \
+      description="Model-mesh is a distributed LRU cache for serving runtime models" \
+      release="${commitSha}" \
+      maintainer="nickhill@us.ibm.com"
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Sample build:
 ```bash
 GIT_COMMIT=$(git rev-parse HEAD)
 BUILD_ID=$(date '+%Y%m%d')-$(git rev-parse HEAD | cut -c -5)
-IMAGE_TAG_VERSION=0.0.1
+IMAGE_TAG_VERSION="dev"
 IMAGE_TAG=${IMAGE_TAG_VERSION}-$(git branch --show-current)_${BUILD_ID}
 
-docker build -t model-mesh:${IMAGE_TAG} \
+docker build -t modelmesh:${IMAGE_TAG} \
     --build-arg imageVersion=${IMAGE_TAG} \
     --build-arg buildId=${BUILD_ID} \
     --build-arg commitSha=${GIT_COMMIT} .


### PR DESCRIPTION
#### Motivation

Fix multi-platform build introduced in PR #80

#### Modifications

Don't use "default" for `ARG`s `TARGETOS` and `TARGETARCH` in `Dockerfile`.

#### Result

Images of [`kserve/modelmesh`](https://hub.docker.com/r/kserve/modelmesh/tags) for platforms `linux/amd64`, `linux/arm64`, `linux/ppc64le`.

#### Related PRs

- https://github.com/kserve/modelmesh/pull/80
- https://github.com/kserve/modelmesh-minio-examples/pull/3
- https://github.com/kserve/modelmesh-runtime-adapter/pull/38
- https://github.com/kserve/modelmesh-serving/pull/314
- https://github.com/kserve/rest-proxy/pull/24
- https://github.com/kserve/modelmesh-serving/pull/371
