### PR TITLE
fix: Fix possible exception-related ByteBuf leak

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/ModelMeshApi.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMeshApi.java
@@ -807,8 +807,8 @@ public final class ModelMeshApi extends ModelMeshGrpc.ModelMeshImplBase
                 Payload payload = null;
                 try {
                     assert payloadProcessor != null;
-                    if (!takeOwnership && data != null) {
-                        ReferenceCountUtil.release(data);
+                    if (!takeOwnership) {
+                        ReferenceCountUtil.retain(data);
                     }
                     payload = new Payload(payloadId, modelId, methodName, metadata, data, status);
                     if (payloadProcessor.process(payload)) {

--- a/src/main/java/com/ibm/watson/modelmesh/ModelMeshApi.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMeshApi.java
@@ -768,6 +768,7 @@ public final class ModelMeshApi extends ModelMeshGrpc.ModelMeshImplBase
                         evictMethodDescriptor(methodName);
                     }
                 } finally {
+                    final boolean releaseResponse = status != OK;
                     if (payloadProcessor != null) {
                         ByteBuf data = null;
                         Metadata metadata = null;
@@ -775,7 +776,9 @@ public final class ModelMeshApi extends ModelMeshGrpc.ModelMeshImplBase
                             data = response.data.readerIndex(respReaderIndex);
                             metadata = response.metadata;
                         }
-                        processPayload(data, requestId, modelId, methodName, metadata, status, false);
+                        processPayload(data, requestId, modelId, methodName, metadata, status, releaseResponse);
+                    } else if (releaseResponse && response != null) {
+                        response.release();
                     }
                     ReleaseAfterResponse.releaseAll();
                     clearThreadLocals();
@@ -804,8 +807,8 @@ public final class ModelMeshApi extends ModelMeshGrpc.ModelMeshImplBase
                 Payload payload = null;
                 try {
                     assert payloadProcessor != null;
-                    if (!takeOwnership) {
-                        data.retain();
+                    if (!takeOwnership && data != null) {
+                        ReferenceCountUtil.release(data);
                     }
                     payload = new Payload(payloadId, modelId, methodName, metadata, data, status);
                     if (payloadProcessor.process(payload)) {


### PR DESCRIPTION
#### Motivation

Some ByteBuf leak errors were reported in a production deployment of model-mesh as described in https://github.com/kserve/modelmesh/issues/97.

#### Modifications

In `ModelMeshApi`, ensure that the response is released if a runtime exception is thrown prior to it being sent successfully.

#### Result

Hopefully leak closed