### PR TITLE
fix: Fix not reading limits when cgroup v2 used

### DIFF
--- a/src/main/scripts/start.sh
+++ b/src/main/scripts/start.sh
@@ -309,11 +309,15 @@ fi
 echo $$ > ${ANCHOR_FILE}
 
 if [ "$MEM_LIMIT_MB" = "" ]; then
-	DOCKER_LIM_FILE="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	CGROUP_V1_LIM_FILE="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	CGROUP_V2_LIM_FILE="/sys/fs/cgroup/memory.max"
 
-	if [ -e "${DOCKER_LIM_FILE}" ]; then
-		MEM_LIMIT_MB=$(($(cat ${DOCKER_LIM_FILE})/1024/1024))
-		echo "Using process mem limit of ${MEM_LIMIT_MB}MiB from ${DOCKER_LIM_FILE}"
+	if [ -e "${CGROUP_V1_LIM_FILE}" ]; then
+		MEM_LIMIT_MB=$(($(cat ${CGROUP_V1_LIM_FILE})/1024/1024))
+		echo "Using process mem limit of ${MEM_LIMIT_MB}MiB from ${CGROUP_V1_LIM_FILE}"
+	elif [ -e "${CGROUP_V2_LIM_FILE}" ]; then
+		MEM_LIMIT_MB=$(($(cat ${CGROUP_V2_LIM_FILE})/1024/1024))
+		echo "Using process mem limit of ${MEM_LIMIT_MB}MiB from ${CGROUP_V2_LIM_FILE}"
 	else
     	MEM_LIMIT_MB="1536"
     	echo "No process mem limit provided or found, defaulting to ${MEM_LIMIT_MB}MiB"


### PR DESCRIPTION
#### Motivation
Docker image was not picking up memory limits when cgroup v2 was used. This lead to incorrect java heap memory limits that lead to crashes due to OOMKilled as described in #106 

#### Modifications
To `start.sh` script that launches application added extra check for limits in [cgroup](https://kubernetes.io/docs/concepts/architecture/cgroups/) v2 file.

#### Result
Docker image works and correctly reads memory limits with both cgroup [v1](http://old-releases.ubuntu.com/releases/) and v2.
