### PR TITLE
Added reader rewind to remote payload processor

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
@@ -83,6 +83,7 @@ public class RemotePayloadProcessor implements PayloadProcessor {
     }
 
     private static String encodeBinaryToString(ByteBuf byteBuf) {
+        byteBuf = byteBuf.readerIndex(0);
         ByteBuf encodedBinary = Base64.encode(byteBuf, byteBuf.readerIndex(), byteBuf.readableBytes(), false);
         //TODO custom jackson serialization for this field to avoid round-tripping to string
         return encodedBinary.toString(StandardCharsets.US_ASCII);

--- a/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
@@ -82,7 +82,7 @@ public class RemotePayloadProcessor implements PayloadProcessor {
         return new PayloadContent(id, modelId, data, kind, status, metadataMap);
     }
 
-    private static String encodeBinaryToString(ByteBuf byteBuf) {
+    static String encodeBinaryToString(ByteBuf byteBuf) {
         byteBuf = byteBuf.readerIndex(0);
         ByteBuf encodedBinary = Base64.encode(byteBuf, byteBuf.readerIndex(), byteBuf.readableBytes(), false);
         //TODO custom jackson serialization for this field to avoid round-tripping to string

--- a/src/test/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessorTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessorTest.java
@@ -42,4 +42,20 @@ class RemotePayloadProcessorTest {
         Payload payload = new Payload(id, modelId, method, metadata, data, kind);
         assertFalse(remotePayloadProcessor.process(payload));
     }
+
+    @Test
+    void testByteBufReaderIndexReset() {
+        ByteBuf byteBuf = Unpooled.wrappedBuffer("{[0, 0.1, 2.3, 4, 5.6]}".getBytes());
+        // mock the payload getting read too early
+        byteBuf.readerIndex(byteBuf.capacity()); // force set reader index to the end of the ByteBuf
+        String encodedString = RemotePayloadProcessor.encodeBinaryToString(byteBuf);
+        assertFalse(encodedString.isEmpty());
+    }
+
+    @Test
+    void testByteBufReaderIndexUntouched() {
+        ByteBuf byteBuf = Unpooled.wrappedBuffer("{[0, 0.1, 2.3, 4, 5.6]}".getBytes());
+        String encodedString = RemotePayloadProcessor.encodeBinaryToString(byteBuf);
+        assertFalse(encodedString.isEmpty());
+    }
 }


### PR DESCRIPTION
#### Motivation
Addresses https://github.com/kserve/modelmesh/issues/111. 

#### Modifications
Adds a byteBuf readerIndex rewind before payloads are parsed in the RemotePayloadProcessor, which deals with any concurrency issues arising from a too-early read of a queued payload. This is a workaround that mitigates the effects of some unknown race condition in bytebuf reading, which should likely still be addressed, but this works in the interim. 

#### Result
Null response payloads no longer occur in high-process-time scenarios