### PR TITLE
fix: Avoid string concat and regex inefficiency

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
@@ -927,7 +927,7 @@ public abstract class ModelMesh extends ThriftService
     // "type" or "type:p1=v1;p2=v2;...;pn=vn"
     private static final Pattern METRICS_CONFIG_PATT = Pattern.compile("([a-z;]+)(:\\w+=[^;]+(?:;\\w+=[^;]+)*)?");
     // "metric_name" or "metric:name;l1=v1,l2=v2,...,ln=vn,"
-    private static final Pattern CUSTOM_METRIC_CONFIG_PATT = Pattern.compile("([a-z_:]+);(\\w+=[^;]+(?:;\\w+=[^,]+)*)?");
+    private static final Pattern CUSTOM_METRIC_CONFIG_PATT = Pattern.compile("([a-z_:]+);(\\w+=[^;]+(?:;\\w+=[^,]++)*)?");
 
     private static Metrics setUpMetrics() throws Exception {
         if (System.getenv("MM_METRICS_STATSD_PORT") != null || System.getenv("MM_METRICS_PROMETHEUS_PORT") != null) {

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshTearDownTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshTearDownTest.java
@@ -315,7 +315,8 @@ public class ModelMeshTearDownTest {
     }
 
     public static int killProcess(Process process) throws Exception {
-        int pid = getPID(process);
-        return Runtime.getRuntime().exec("kill -9 " + pid).waitFor();
+        String pid = Integer.toString(getPID(process));
+        String command = "kill -9";
+        return Runtime.getRuntime().exec(new String[] {command, pid}).waitFor();
     }
 }

--- a/src/test/java/com/ibm/watson/modelmesh/ModelMeshTearDownTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/ModelMeshTearDownTest.java
@@ -316,7 +316,6 @@ public class ModelMeshTearDownTest {
 
     public static int killProcess(Process process) throws Exception {
         String pid = Integer.toString(getPID(process));
-        String command = "kill -9";
-        return Runtime.getRuntime().exec(new String[] {command, pid}).waitFor();
+        return Runtime.getRuntime().exec(new String[] {"kill", "-9", pid}).waitFor();
     }
 }


### PR DESCRIPTION
This PR makes the following changes:

- Execute external commands using an array of strings rather than a single string as per https://github.com/kserve/modelmesh/security/code-scanning/2 
- Make the regular expression pattern a bit more efficient
https://github.com/kserve/modelmesh/security/code-scanning/1