### PR TITLE
Bump ubi8 tag to 8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6 as build_base
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8 as build_base
 
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 # don't provide "default" values (e.g. 'ARG TARGETARCH=amd64') for non-buildx environments,


### PR DESCRIPTION
chore: update ubi8-minimal to latest version, 8.8. Vulnerabities fixed:
- [RHSA-2023:7165]( https://access.redhat.com/errata/RHSA-2023:7151): cups security and bug fix update (Moderate)
- [RHSA-2023:7151](https://access.redhat.com/errata/RHSA-2023:7151): python3 security update (Moderate)
- [RHSA-2023:7176](https://access.redhat.com/errata/RHSA-2023:7176): python-pip security update (Moderate)
- [RHSA-2023:7151](https://access.redhat.com/errata/RHSA-2023:7151): python3 security update (Moderate)
- [RHSA-2023:7190](https://access.redhat.com/errata/RHSA-2023:7190): avahi security update (Moderate)
- [RHSA-2023:7112](https://access.redhat.com/errata/RHSA-2023:7112): shadow-utils security and bug fix update (Low)

#### Motivation


#### Modifications


#### Result
