### PR TITLE
feat: Add vModelId to PayloadProcessor Payload

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/ModelMeshApi.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMeshApi.java
@@ -767,7 +767,7 @@ public final class ModelMeshApi extends ModelMeshGrpc.ModelMeshImplBase
                     } finally {
                         if (payloadProcessor != null) {
                             processPayload(reqMessage.readerIndex(reqReaderIndex),
-                                    requestId, resolvedModelId, methodName, headers, null, true);
+                                    requestId, resolvedModelId, vModelId, methodName, headers, null, true);
                         } else {
                             releaseReqMessage();
                         }
@@ -803,7 +803,7 @@ public final class ModelMeshApi extends ModelMeshGrpc.ModelMeshImplBase
                             data = response.data.readerIndex(respReaderIndex);
                             metadata = response.metadata;
                         }
-                        processPayload(data, requestId, resolvedModelId, methodName, metadata, status, releaseResponse);
+                        processPayload(data, requestId, resolvedModelId, vModelId, methodName, metadata, status, releaseResponse);
                     } else if (releaseResponse && response != null) {
                         response.release();
                     }
@@ -829,7 +829,7 @@ public final class ModelMeshApi extends ModelMeshGrpc.ModelMeshImplBase
              * @param status null for requests, non-null for responses
              * @param takeOwnership whether the processor should take ownership
              */
-            private void processPayload(ByteBuf data, String payloadId, String modelId, String methodName,
+            private void processPayload(ByteBuf data, String payloadId, String vModelId, String modelId, String methodName,
                                         Metadata metadata, io.grpc.Status status, boolean takeOwnership) {
                 Payload payload = null;
                 try {
@@ -837,7 +837,7 @@ public final class ModelMeshApi extends ModelMeshGrpc.ModelMeshImplBase
                     if (!takeOwnership) {
                         ReferenceCountUtil.retain(data);
                     }
-                    payload = new Payload(payloadId, modelId, methodName, metadata, data, status);
+                    payload = new Payload(payloadId, modelId, vModelId, methodName, metadata, data, status);
                     if (payloadProcessor.process(payload)) {
                         data = null; // ownership transferred
                     }

--- a/src/main/java/com/ibm/watson/modelmesh/payload/Payload.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/Payload.java
@@ -39,6 +39,8 @@ public class Payload {
 
     private final String modelId;
 
+    private final String vModelId;
+
     private final String method;
 
     private final Metadata metadata;
@@ -48,10 +50,17 @@ public class Payload {
     // null for requests, non-null for responses
     private final Status status;
 
+
     public Payload(@Nonnull String id, @Nonnull String modelId, @Nullable String method, @Nullable Metadata metadata,
                    @Nullable ByteBuf data, @Nullable Status status) {
+        this(id, modelId, null, method, metadata, data, status);
+    }
+
+    public Payload(@Nonnull String id, @Nonnull String modelId, @Nullable String vModelId, @Nullable String method,
+                   @Nullable Metadata metadata, @Nullable ByteBuf data, @Nullable Status status) {
         this.id = id;
         this.modelId = modelId;
+        this.vModelId = vModelId;
         this.method = method;
         this.metadata = metadata;
         this.data = data;
@@ -66,6 +75,16 @@ public class Payload {
     @Nonnull
     public String getModelId() {
         return modelId;
+    }
+
+    @CheckForNull
+    public String getVModelId() {
+        return vModelId;
+    }
+
+    @Nonnull
+    public String getVModelIdOrModelId() {
+        return vModelId != null ? vModelId : modelId;
     }
 
     @CheckForNull
@@ -101,6 +120,7 @@ public class Payload {
     public String toString() {
         return "Payload{" +
                 "id='" + id + '\'' +
+                ", vModelId=" + (vModelId != null ? ('\'' + vModelId + '\'') : "null") +
                 ", modelId='" + modelId + '\'' +
                 ", method='" + method + '\'' +
                 ", status=" + (status == null ? "request" : String.valueOf(status)) +

--- a/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
@@ -57,14 +57,10 @@ public class RemotePayloadProcessor implements PayloadProcessor {
     private static PayloadContent prepareContentBody(Payload payload) {
         String id = payload.getId();
         String modelId = payload.getModelId();
+        String vModelId = payload.getVModelId();
         String kind = payload.getKind().toString().toLowerCase();
         ByteBuf byteBuf = payload.getData();
-        String data;
-        if (byteBuf != null) {
-            data = encodeBinaryToString(byteBuf);
-        } else {
-            data = "";
-        }
+        String data = byteBuf != null ? encodeBinaryToString(byteBuf) : "";
         Metadata metadata = payload.getMetadata();
         Map<String, String> metadataMap = new HashMap<>();
         if (metadata != null) {
@@ -79,7 +75,7 @@ public class RemotePayloadProcessor implements PayloadProcessor {
             }
         }
         String status = payload.getStatus() != null ? payload.getStatus().getCode().toString() : "";
-        return new PayloadContent(id, modelId, data, kind, status, metadataMap);
+        return new PayloadContent(id, modelId, vModelId, data, kind, status, metadataMap);
     }
 
     private static String encodeBinaryToString(ByteBuf byteBuf) {
@@ -116,15 +112,17 @@ public class RemotePayloadProcessor implements PayloadProcessor {
 
         private final String id;
         private final String modelid;
+        private final String vModelId;
         private final String data;
         private final String kind;
         private final String status;
         private final Map<String, String> metadata;
 
-        private PayloadContent(String id, String modelid, String data, String kind, String status,
-                               Map<String, String> metadata) {
+        private PayloadContent(String id, String modelid, String vModelId, String data, String kind,
+                               String status, Map<String, String> metadata) {
             this.id = id;
             this.modelid = modelid;
+            this.vModelId = vModelId;
             this.data = data;
             this.kind = kind;
             this.status = status;
@@ -141,6 +139,10 @@ public class RemotePayloadProcessor implements PayloadProcessor {
 
         public String getModelid() {
             return modelid;
+        }
+
+        public String getvModelId() {
+            return vModelId;
         }
 
         public String getData() {
@@ -160,6 +162,7 @@ public class RemotePayloadProcessor implements PayloadProcessor {
             return "PayloadContent{" +
                     "id='" + id + '\'' +
                     ", modelid='" + modelid + '\'' +
+                    ", vModelId=" + (vModelId != null ? ('\'' + vModelId + '\'') : "null") +
                     ", data='" + data + '\'' +
                     ", kind='" + kind + '\'' +
                     ", status='" + status + '\'' +


### PR DESCRIPTION
#### Motivation

Currently the payloads passed to PayloadProcessors only contain the modelId, which in the case of vModels will be a "resolved" modelId corresponding to a particular model revision (in particular this will be true when used in KServe modelmesh-serving). It would be useful to include the vModelId too.

#### Modifications

Add a `vModelId` field to the `Payload` class and correspondingly update built-in `PayloadProcessor` implementations where applicable.

It may be null if the request was directed at a concrete modelId rather than a vModelId.

#### Result

Both modelId and vModelId are available to PayloadProcessors