### PR TITLE
Use SSL context/params in RPP for HTTPS

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
@@ -31,6 +31,9 @@ import io.netty.handler.codec.base64.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
 /**
  * A {@link PayloadProcessor} that sends payloads to a remote service via HTTP POST.
  */
@@ -41,12 +44,27 @@ public class RemotePayloadProcessor implements PayloadProcessor {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private final URI uri;
+    private final SSLContext sslContext;
+    private final SSLParameters sslParameters;
 
     private final HttpClient client;
 
     public RemotePayloadProcessor(URI uri) {
+        this(uri, null, null);
+    }
+
+    public RemotePayloadProcessor(URI uri, SSLContext sslContext, SSLParameters sslParameters) {
         this.uri = uri;
-        this.client = HttpClient.newHttpClient();
+        this.sslContext = sslContext;
+        this.sslParameters = sslParameters;
+        if (sslContext != null && sslParameters != null) {
+            this.client = HttpClient.newBuilder()
+                    .sslContext(sslContext)
+                    .sslParameters(sslParameters)
+                    .build();
+        } else {
+            this.client = HttpClient.newHttpClient();
+        }
     }
 
     @Override

--- a/src/test/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessorTest.java
+++ b/src/test/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessorTest.java
@@ -16,7 +16,9 @@
 
 package com.ibm.watson.modelmesh.payload;
 
+import java.io.IOException;
 import java.net.URI;
+import java.security.NoSuchAlgorithmException;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -24,22 +26,46 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class RemotePayloadProcessorTest {
 
     @Test
-    void testDestinationUnreachable() {
-        RemotePayloadProcessor remotePayloadProcessor = new RemotePayloadProcessor(URI.create("http://this-does-not-exist:123"));
-        String id = "123";
-        String modelId = "456";
-        String method = "predict";
-        Status kind = Status.INVALID_ARGUMENT;
-        Metadata metadata = new Metadata();
-        metadata.put(Metadata.Key.of("foo", Metadata.ASCII_STRING_MARSHALLER), "bar");
-        metadata.put(Metadata.Key.of("binary-bin", Metadata.BINARY_BYTE_MARSHALLER), "string".getBytes());
-        ByteBuf data = Unpooled.buffer(4);
-        Payload payload = new Payload(id, modelId, method, metadata, data, kind);
-        assertFalse(remotePayloadProcessor.process(payload));
+    void testDestinationUnreachable() throws IOException {
+        URI uri = URI.create("http://this-does-not-exist:123");
+        try (RemotePayloadProcessor remotePayloadProcessor = new RemotePayloadProcessor(uri)) {
+            String id = "123";
+            String modelId = "456";
+            String method = "predict";
+            Status kind = Status.INVALID_ARGUMENT;
+            Metadata metadata = new Metadata();
+            metadata.put(Metadata.Key.of("foo", Metadata.ASCII_STRING_MARSHALLER), "bar");
+            metadata.put(Metadata.Key.of("binary-bin", Metadata.BINARY_BYTE_MARSHALLER), "string".getBytes());
+            ByteBuf data = Unpooled.buffer(4);
+            Payload payload = new Payload(id, modelId, method, metadata, data, kind);
+            assertFalse(remotePayloadProcessor.process(payload));
+        }
+    }
+
+    @Test
+    void testDestinationUnreachableHTTPS() throws IOException, NoSuchAlgorithmException {
+        URI uri = URI.create("https://this-does-not-exist:123");
+        SSLContext sslContext = SSLContext.getDefault();
+        SSLParameters sslParameters = sslContext.getDefaultSSLParameters();
+        try (RemotePayloadProcessor remotePayloadProcessor = new RemotePayloadProcessor(uri, sslContext, sslParameters)) {
+            String id = "123";
+            String modelId = "456";
+            String method = "predict";
+            Status kind = Status.INVALID_ARGUMENT;
+            Metadata metadata = new Metadata();
+            metadata.put(Metadata.Key.of("foo", Metadata.ASCII_STRING_MARSHALLER), "bar");
+            metadata.put(Metadata.Key.of("binary-bin", Metadata.BINARY_BYTE_MARSHALLER), "string".getBytes());
+            ByteBuf data = Unpooled.buffer(4);
+            Payload payload = new Payload(id, modelId, method, metadata, data, kind);
+            assertFalse(remotePayloadProcessor.process(payload));
+        }
     }
 }


### PR DESCRIPTION
#### Motivation
Need to better support remote payload processing in terms of secure connections.

#### Modifications
We allow injecting `SSLContext` (with `SSLParameters`) into `RemotePayloadProcessor`'s `HttpClient`.

#### Result
Supporting sending payloads to remote endpoints over HTTPS.