### PR TITLE
deps: update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <!--suppress UnresolvedMavenProperty -->
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
-    <grpc-version>1.62.2</grpc-version>
+    <grpc-version>1.60.2</grpc-version>
     <netty-version>4.1.108.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,25 +57,25 @@
     <!--suppress UnresolvedMavenProperty -->
     <jenkins-build-tag>${env.BUILD_TAG}</jenkins-build-tag>  <!-- set by jenkins -->
 
-    <grpc-version>1.59.0</grpc-version>
-    <netty-version>4.1.100.Final</netty-version>
+    <grpc-version>1.62.2</grpc-version>
+    <netty-version>4.1.108.Final</netty-version>
     <litelinks-version>1.7.2</litelinks-version>
     <kv-utils-version>0.5.1</kv-utils-version>
     <etcd-java-version>0.0.24</etcd-java-version>
-    <protobuf-version>3.25.0</protobuf-version>
-    <annotation-version>9.0.82</annotation-version>
-    <guava-version>32.1.3-jre</guava-version>
-    <jackson-databind-version>2.16.0</jackson-databind-version>
+    <protobuf-version>3.25.3</protobuf-version>
+    <annotation-version>9.0.87</annotation-version>
+    <guava-version>33.1.0-jre</guava-version>
+    <jackson-databind-version>2.16.2</jackson-databind-version>
     <gson-version>2.10.1</gson-version>
-    <thrift-version>0.19.0</thrift-version>
+    <thrift-version>0.20.0</thrift-version>
     <eclipse-collections-version>11.1.0</eclipse-collections-version>
-    <log4j2-version>2.21.1</log4j2-version>
+    <log4j2-version>2.23.1</log4j2-version>
     <slf4j-version>1.7.36</slf4j-version>
     <!-- Care must be taken when updating the prometheus client lib version
          since we have some custom optimized extensions to this -->
     <prometheus-version>0.9.0</prometheus-version>
-    <bouncycastle-version>1.74</bouncycastle-version>
-    <junit-version>5.10.1</junit-version>
+    <bouncycastle-version>1.77</bouncycastle-version>
+    <junit-version>5.10.2</junit-version>
 
     <zookeeper-version>3.8.4</zookeeper-version>
     <curator-version>5.3.0</curator-version>


### PR DESCRIPTION
#### Motivation
Update dependencies to keep them up-to-date. 
In particular want to update netty ito resolve [CVE](https://www.cve.org/CVERecord?id=CVE-2024-29025) with `io.netty_netty-codec-http` picked up by twistlock

#### Modifications
grpc 1.60.2, netty 4.1.108, protobuf 3.25.3, annotations 9.0.87, guava 33.1.0-jre, jackson-databind 2.16.2, thrift 0.20.0, log4j2 2.23.1, bouncycastle 1.77, junit 5.10.2

Note that grpc-java v1.59.1 [resolved issue](https://github.com/grpc/grpc-java/issues/10665#issuecomment-1830242271) with supporting netty 4.1.101.Final