### PR TITLE
ci: Add nightly build twice a week

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * 1,4'  # midnight US/Pacific on Sundays and Wednesdays
   pull_request:
     branches:
       - main


### PR DESCRIPTION
#### Motivation

https://github.com/kserve/modelmesh-serving/issues/508#issuecomment-2147943188

#### Modifications

Add [cron schedule](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) build trigger

---

FYI @spolti 
