### PR TITLE
Remove unnecessary fields from ModelMesh logs

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/payload/Payload.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/Payload.java
@@ -124,8 +124,6 @@ public class Payload {
                 ", modelId='" + modelId + '\'' +
                 ", method='" + method + '\'' +
                 ", status=" + (status == null ? "request" : String.valueOf(status)) +
-                ", metadata=" + metadata +
-                ", data=" + (data != null ? data.readableBytes() + "B" : "") +
                 '}';
     }
 }

--- a/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
@@ -95,7 +95,7 @@ public class RemotePayloadProcessor implements PayloadProcessor {
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() != 200) {
-                logger.warn("Processing {} with request {} didn't succeed: {}", payload, payloadContent, response);
+                logger.warn("Processing {} didn't succeed: {}", payload, response);
             }
         } catch (Throwable e) {
             logger.error("An error occurred while sending payload {} to {}: {}", payload, uri, e.getCause());
@@ -163,10 +163,8 @@ public class RemotePayloadProcessor implements PayloadProcessor {
                     "id='" + id + '\'' +
                     ", modelid='" + modelid + '\'' +
                     ", vModelId=" + (vModelId != null ? ('\'' + vModelId + '\'') : "null") +
-                    ", data='" + data + '\'' +
                     ", kind='" + kind + '\'' +
                     ", status='" + status + '\'' +
-                    ", metadata='" + metadata + '\'' +
                     '}';
         }
     }

--- a/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
+++ b/src/main/java/com/ibm/watson/modelmesh/payload/RemotePayloadProcessor.java
@@ -163,8 +163,10 @@ public class RemotePayloadProcessor implements PayloadProcessor {
                     "id='" + id + '\'' +
                     ", modelid='" + modelid + '\'' +
                     ", vModelId=" + (vModelId != null ? ('\'' + vModelId + '\'') : "null") +
+                    ", data='" + data + '\'' +
                     ", kind='" + kind + '\'' +
                     ", status='" + status + '\'' +
+                    ", metadata='" + metadata + '\'' +
                     '}';
         }
     }


### PR DESCRIPTION
Payload processor logs display the entirety of the `Payload`, including metadata and request contents.
This is not necessary at the log level.