### PR TITLE
fix: Allow continously used caches to be scaled to 2 copies

### DIFF
--- a/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
+++ b/src/main/java/com/ibm/watson/modelmesh/ModelMesh.java
@@ -5738,7 +5738,10 @@ public abstract class ModelMesh extends ThriftService
                                         i1inRange = i1 >= lower;
                                         i2inRange = i2 <= upper;
                                     }
-                                    if (i2inRange || !i1inRange) {
+                                    // Do not update earlierUseIteration when i1 > upper, so that if the model is being
+                                    // used continously, i1 will not be updated to the lastUsedIteration but be able to
+                                    // fall in range of lower and upper interval.
+                                    if (i2inRange || (i1 < lower)) {
                                         ce.earlierUseIteration = i2;
                                     }
                                     ce.lastUsedIteration = iterationCounter;


### PR DESCRIPTION
#### Motivation

- The earlierUseIteration (i1) is updated when i1 are not in range, including two cases: i1 is smaller than the lower bound (40m ago) and larger than the upper bound (7m ago).
- Therefore, if a model is used continously, the earlierUseIteration (i1) will always be larger than the upper bound and will never be in range. To be scaled to 2 copies, the model has to be used once, wait for 7 minutes WITHOUT ANY other usage, if any other usage appear, it will interrupt (update the earlierUseIteration to the lastUsedIteration).

#### Modifications

- Only update the earlierUseIteration if i1 smaller than the lower bound, not when i1 larger than the upper bound.

#### Results:

- A model that is continuously used will be abled to two copies, maintain the HA of that model.





